### PR TITLE
Add transformer model support, LoRA fine-tuning, and hardened training loop

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -116,3 +116,107 @@ jobs:
         flags: cpu,unittest,python${{ matrix.python-version }}
         name: CPU-coverage
         fail_ci_if_error: false
+
+  # ── Transformer / foundation-model test suite ──────────────────────────────
+  # Runs the 7 new test files that cover ModelOutputAdapter, HuggingFace
+  # wrappers, timm decoder, TerraTorch wrapper, LoRA fine-tuning, hardened
+  # training loop, and the updated inference pipeline.
+  #
+  # Install the optional extras with:
+  #   pip install pytorch_segmentation_models_trainer[transformers]
+  # ──────────────────────────────────────────────────────────────────────────
+  test-transformers:
+    runs-on: ubuntu-latest
+    env:
+      HYDRA_FULL_ERROR: 1
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Get pip cache dir
+      id: pip-cache
+      run: echo "::set-output name=dir::$(pip cache dir)"
+
+    - name: pip cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-transformers-${{ hashFiles('**/requirements.txt', '**/setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-transformers-
+          ${{ runner.os }}-pip-
+
+    # CPU-only PyTorch keeps the image small and the job fast.
+    - name: Install PyTorch (CPU)
+      run: |
+        python -m pip install --upgrade pip
+        pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+
+    # Install the package with the [transformers] extras group.
+    # This brings in: transformers, peft, timm (+ all base requirements).
+    - name: Install package with transformer extras
+      run: |
+        pip install flake8 pytest coverage pytest-timeout
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install ".[transformers]"
+        # OpenCV headless to avoid GUI deps on the runner
+        pip uninstall opencv-python opencv-python-headless -y || true
+        pip install opencv-python-headless
+
+    - name: Lint new files with flake8
+      run: |
+        flake8 \
+          pytorch_segmentation_models_trainer/custom_models/transformer_adapters.py \
+          pytorch_segmentation_models_trainer/custom_models/huggingface_models.py \
+          pytorch_segmentation_models_trainer/custom_models/timm_models.py \
+          pytorch_segmentation_models_trainer/custom_models/terratorch_models.py \
+          pytorch_segmentation_models_trainer/fine_tuning/ \
+          pytorch_segmentation_models_trainer/config_definitions/fine_tuning_config.py \
+          --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 \
+          pytorch_segmentation_models_trainer/custom_models/transformer_adapters.py \
+          pytorch_segmentation_models_trainer/custom_models/huggingface_models.py \
+          pytorch_segmentation_models_trainer/custom_models/timm_models.py \
+          pytorch_segmentation_models_trainer/custom_models/terratorch_models.py \
+          pytorch_segmentation_models_trainer/fine_tuning/ \
+          pytorch_segmentation_models_trainer/config_definitions/fine_tuning_config.py \
+          --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+    - name: Run transformer test suite
+      run: |
+        coverage run \
+          --source pytorch_segmentation_models_trainer \
+          --omit pytorch_segmentation_models_trainer/custom_models/sync_bn/* \
+          -m pytest \
+            tests/test_transformer_adapters.py \
+            tests/test_huggingface_models.py \
+            tests/test_timm_models.py \
+            tests/test_fine_tuning.py \
+            tests/test_model_training_step.py \
+            tests/test_terratorch_models.py \
+            tests/test_inference_pipeline.py \
+          --timeout=120 \
+          -v \
+          -p no:warnings
+
+    - name: Coverage report
+      if: success()
+      run: |
+        coverage report
+        coverage xml
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      if: always()
+      continue-on-error: true
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: coverage.xml
+        flags: cpu,transformers,unittest
+        name: CPU-transformers-coverage
+        fail_ci_if_error: false

--- a/pytorch_segmentation_models_trainer/conf/examples/prithvi_terratorch.yaml
+++ b/pytorch_segmentation_models_trainer/conf/examples/prithvi_terratorch.yaml
@@ -1,0 +1,117 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Example: TerraTorch Prithvi-100M geospatial foundation model
+# ──────────────────────────────────────────────────────────────────────────────
+# Requires: pip install terratorch
+#
+# Prithvi is a ViT-based geospatial foundation model pretrained on
+# Harmonized Landsat-Sentinel-2 (HLS) data with 6 spectral bands.
+# Single-temporal inputs (B, 6, H, W) are auto-expanded to (B, 6, 1, H, W).
+#
+# Download pretrained weights from HuggingFace:
+#   https://huggingface.co/ibm-nasa-geospatial/Prithvi-100M
+# ──────────────────────────────────────────────────────────────────────────────
+
+defaults:
+  - _self_
+
+backbone:
+  name: prithvi_100M
+  input_width: 224
+  input_height: 224
+
+hyperparameters:
+  model_name: prithvi_100M_seg
+  backbone: prithvi_100M
+  batch_size: 4
+  epochs: 50
+  max_lr: 1e-4
+  classes: 2
+
+model:
+  _target_: pytorch_segmentation_models_trainer.custom_models.terratorch_models.TerraTorchSegmentationWrapper
+  backbone_name: prithvi_100M
+  num_classes: ${hyperparameters.classes}
+  in_channels: 6                   # HLS: Blue, Green, Red, NIR, SWIR1, SWIR2
+  num_frames: 1                    # single time step
+  img_size: ${backbone.input_height}
+  head_type: linear                # "linear" or "fpn"
+  pretrained_path: /weights/prithvi_100M.pt   # path to downloaded weights
+
+# Fine-tune only the segmentation head; keep the backbone frozen
+fine_tuning:
+  strategy: freeze_backbone
+  frozen_modules: [backbone]
+  trainable_modules: [head]
+
+loss:
+  _target_: segmentation_models_pytorch.losses.DiceLoss
+  mode: multiclass
+  from_logits: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: ${hyperparameters.max_lr}
+  weight_decay: 1e-4
+
+scheduler_list:
+  - scheduler:
+      _target_: torch.optim.lr_scheduler.CosineAnnealingLR
+      T_max: ${hyperparameters.epochs}
+      eta_min: 1e-7
+    interval: epoch
+    frequency: 1
+
+pl_trainer:
+  max_epochs: ${hyperparameters.epochs}
+  accelerator: auto
+  devices: 1
+  precision: "16-mixed"
+
+# NOTE: 6-band input – update Normalize mean/std to match your dataset statistics
+train_dataset:
+  _target_: pytorch_segmentation_models_trainer.dataset_loader.dataset.SegmentationDataset
+  input_csv_path: /data/train.csv
+  root_dir: /data
+  augmentation_list:
+    - _target_: albumentations.Resize
+      height: ${backbone.input_height}
+      width: ${backbone.input_width}
+    - _target_: albumentations.HorizontalFlip
+      p: 0.5
+    - _target_: albumentations.Normalize
+      mean: [0.033, 0.046, 0.045, 0.195, 0.106, 0.071]   # HLS statistics
+      std:  [0.023, 0.027, 0.031, 0.061, 0.052, 0.044]
+    - _target_: albumentations.pytorch.ToTensorV2
+  data_loader:
+    batch_size: ${hyperparameters.batch_size}
+    num_workers: 4
+    shuffle: true
+    pin_memory: true
+    drop_last: true
+
+val_dataset:
+  _target_: pytorch_segmentation_models_trainer.dataset_loader.dataset.SegmentationDataset
+  input_csv_path: /data/val.csv
+  root_dir: /data
+  augmentation_list:
+    - _target_: albumentations.Resize
+      height: ${backbone.input_height}
+      width: ${backbone.input_width}
+    - _target_: albumentations.Normalize
+      mean: [0.033, 0.046, 0.045, 0.195, 0.106, 0.071]
+      std:  [0.023, 0.027, 0.031, 0.061, 0.052, 0.044]
+    - _target_: albumentations.pytorch.ToTensorV2
+  data_loader:
+    batch_size: ${hyperparameters.batch_size}
+    num_workers: 4
+    shuffle: false
+    pin_memory: true
+    drop_last: false
+
+metrics:
+  - _target_: torchmetrics.JaccardIndex
+    task: multiclass
+    num_classes: ${hyperparameters.classes}
+  - _target_: torchmetrics.F1Score
+    task: multiclass
+    num_classes: ${hyperparameters.classes}

--- a/pytorch_segmentation_models_trainer/conf/examples/segformer_hf.yaml
+++ b/pytorch_segmentation_models_trainer/conf/examples/segformer_hf.yaml
@@ -1,0 +1,117 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Example: HuggingFace Segformer-B2 via HuggingFaceSegmentationWrapper
+# ──────────────────────────────────────────────────────────────────────────────
+# Requires: pip install transformers
+#
+# The wrapper handles:
+#   - Loading the model from HuggingFace Hub (or a local path)
+#   - Extracting logits from the SegmentationModelOutput dataclass
+#   - Upsampling the 1/4-resolution output back to input size
+#
+# Normalisation mean/std must match the model's pretraining stats.
+# Segformer was pretrained with ImageNet stats.
+# ──────────────────────────────────────────────────────────────────────────────
+
+defaults:
+  - _self_
+
+backbone:
+  name: segformer_b2
+  input_width: 512
+  input_height: 512
+
+hyperparameters:
+  model_name: segformer_b2_hf
+  backbone: segformer_b2
+  batch_size: 8
+  epochs: 50
+  max_lr: 6e-5
+  classes: 2
+
+# Use HuggingFaceSegmentationWrapper to normalise the HF model output
+model:
+  _target_: pytorch_segmentation_models_trainer.custom_models.huggingface_models.HuggingFaceSegmentationWrapper
+  pretrained_model_name_or_path: nvidia/mit-b2
+  num_labels: ${hyperparameters.classes}
+  ignore_mismatched_sizes: true
+  output_size: input       # upsample logits (H/4,W/4) → input size
+
+# Or alternatively, use ModelOutputAdapter directly for full control:
+# model:
+#   _target_: pytorch_segmentation_models_trainer.custom_models.transformer_adapters.ModelOutputAdapter
+#   output_size: input
+#   model:
+#     _target_: transformers.AutoModelForSemanticSegmentation.from_pretrained
+#     pretrained_model_name_or_path: nvidia/segformer-b2-finetuned-ade-512-512
+#     num_labels: 2
+#     ignore_mismatched_sizes: true
+
+loss:
+  _target_: torch.nn.CrossEntropyLoss
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: ${hyperparameters.max_lr}
+  weight_decay: 1e-4
+
+scheduler_list:
+  - scheduler:
+      _target_: torch.optim.lr_scheduler.PolynomialLR
+      total_iters: ${hyperparameters.epochs}
+      power: 1.0
+    interval: epoch
+    frequency: 1
+
+pl_trainer:
+  max_epochs: ${hyperparameters.epochs}
+  accelerator: auto
+  devices: 1
+  precision: "16-mixed"
+
+train_dataset:
+  _target_: pytorch_segmentation_models_trainer.dataset_loader.dataset.SegmentationDataset
+  input_csv_path: /data/train.csv
+  root_dir: /data
+  augmentation_list:
+    - _target_: albumentations.Resize
+      height: ${backbone.input_height}
+      width: ${backbone.input_width}
+    - _target_: albumentations.HorizontalFlip
+      p: 0.5
+    - _target_: albumentations.Normalize
+      mean: [0.485, 0.456, 0.406]   # ImageNet stats used by Segformer
+      std: [0.229, 0.224, 0.225]
+    - _target_: albumentations.pytorch.ToTensorV2
+  data_loader:
+    batch_size: ${hyperparameters.batch_size}
+    num_workers: 8
+    shuffle: true
+    pin_memory: true
+    drop_last: true
+
+val_dataset:
+  _target_: pytorch_segmentation_models_trainer.dataset_loader.dataset.SegmentationDataset
+  input_csv_path: /data/val.csv
+  root_dir: /data
+  augmentation_list:
+    - _target_: albumentations.Resize
+      height: ${backbone.input_height}
+      width: ${backbone.input_width}
+    - _target_: albumentations.Normalize
+      mean: [0.485, 0.456, 0.406]
+      std: [0.229, 0.224, 0.225]
+    - _target_: albumentations.pytorch.ToTensorV2
+  data_loader:
+    batch_size: ${hyperparameters.batch_size}
+    num_workers: 8
+    shuffle: false
+    pin_memory: true
+    drop_last: false
+
+metrics:
+  - _target_: torchmetrics.JaccardIndex
+    task: multiclass
+    num_classes: ${hyperparameters.classes}
+  - _target_: torchmetrics.F1Score
+    task: multiclass
+    num_classes: ${hyperparameters.classes}

--- a/pytorch_segmentation_models_trainer/conf/examples/segformer_lora.yaml
+++ b/pytorch_segmentation_models_trainer/conf/examples/segformer_lora.yaml
@@ -1,0 +1,113 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Example: HuggingFace Segformer-B2 with LoRA fine-tuning
+# ──────────────────────────────────────────────────────────────────────────────
+# Requires: pip install transformers peft
+#
+# LoRA adds low-rank adapter matrices to the attention query/value projections.
+# Only the adapter parameters (+ the segmentation head) are trained, reducing
+# GPU memory and overfitting risk when fine-tuning on small datasets.
+#
+# Typical trainable parameter reduction: ~97% frozen, ~3% trainable.
+# ──────────────────────────────────────────────────────────────────────────────
+
+defaults:
+  - _self_
+
+backbone:
+  name: segformer_b2_lora
+  input_width: 512
+  input_height: 512
+
+hyperparameters:
+  model_name: segformer_b2_lora
+  backbone: segformer_b2
+  batch_size: 8
+  epochs: 30
+  max_lr: 2e-4   # Higher LR is typical for LoRA
+  classes: 2
+
+model:
+  _target_: pytorch_segmentation_models_trainer.custom_models.huggingface_models.HuggingFaceSegmentationWrapper
+  pretrained_model_name_or_path: nvidia/mit-b2
+  num_labels: ${hyperparameters.classes}
+  ignore_mismatched_sizes: true
+  output_size: input
+
+# LoRA fine-tuning strategy applied on top of the model
+fine_tuning:
+  strategy: lora
+  lora_config:
+    r: 16
+    lora_alpha: 32
+    lora_dropout: 0.1
+    bias: none
+    target_modules:
+      - query
+      - value
+
+loss:
+  _target_: torch.nn.CrossEntropyLoss
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: ${hyperparameters.max_lr}
+  weight_decay: 1e-4
+
+scheduler_list:
+  - scheduler:
+      _target_: torch.optim.lr_scheduler.CosineAnnealingLR
+      T_max: ${hyperparameters.epochs}
+      eta_min: 1e-7
+    interval: epoch
+    frequency: 1
+
+pl_trainer:
+  max_epochs: ${hyperparameters.epochs}
+  accelerator: auto
+  devices: 1
+  precision: "16-mixed"
+
+train_dataset:
+  _target_: pytorch_segmentation_models_trainer.dataset_loader.dataset.SegmentationDataset
+  input_csv_path: /data/train.csv
+  root_dir: /data
+  augmentation_list:
+    - _target_: albumentations.Resize
+      height: ${backbone.input_height}
+      width: ${backbone.input_width}
+    - _target_: albumentations.HorizontalFlip
+      p: 0.5
+    - _target_: albumentations.Normalize
+      mean: [0.485, 0.456, 0.406]
+      std: [0.229, 0.224, 0.225]
+    - _target_: albumentations.pytorch.ToTensorV2
+  data_loader:
+    batch_size: ${hyperparameters.batch_size}
+    num_workers: 8
+    shuffle: true
+    pin_memory: true
+    drop_last: true
+
+val_dataset:
+  _target_: pytorch_segmentation_models_trainer.dataset_loader.dataset.SegmentationDataset
+  input_csv_path: /data/val.csv
+  root_dir: /data
+  augmentation_list:
+    - _target_: albumentations.Resize
+      height: ${backbone.input_height}
+      width: ${backbone.input_width}
+    - _target_: albumentations.Normalize
+      mean: [0.485, 0.456, 0.406]
+      std: [0.229, 0.224, 0.225]
+    - _target_: albumentations.pytorch.ToTensorV2
+  data_loader:
+    batch_size: ${hyperparameters.batch_size}
+    num_workers: 8
+    shuffle: false
+    pin_memory: true
+    drop_last: false
+
+metrics:
+  - _target_: torchmetrics.JaccardIndex
+    task: multiclass
+    num_classes: ${hyperparameters.classes}

--- a/pytorch_segmentation_models_trainer/conf/examples/smp_mit_b2.yaml
+++ b/pytorch_segmentation_models_trainer/conf/examples/smp_mit_b2.yaml
@@ -1,0 +1,106 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Example: SMP + Mix Transformer (MiT-B2) encoder
+# ──────────────────────────────────────────────────────────────────────────────
+# This config uses segmentation_models_pytorch with the MiT-B2 transformer
+# encoder.  No extra dependencies required — SMP ships transformer encoders
+# out of the box.
+#
+# MiT encoders available: mit_b0 … mit_b5
+# Architectures: Unet, UnetPlusPlus, FPN, DeepLabV3Plus, PAN, PSPNet
+# ──────────────────────────────────────────────────────────────────────────────
+
+defaults:
+  - _self_
+
+backbone:
+  name: mit_b2
+  input_width: 512
+  input_height: 512
+
+hyperparameters:
+  model_name: unet_mit_b2
+  backbone: mit_b2
+  batch_size: 8
+  epochs: 50
+  max_lr: 6e-5
+  classes: 2
+
+model:
+  _target_: segmentation_models_pytorch.Unet
+  encoder_name: mit_b2
+  encoder_weights: imagenet
+  in_channels: 3
+  classes: ${hyperparameters.classes}
+  decoder_channels: [256, 128, 64, 32, 16]
+
+loss:
+  _target_: segmentation_models_pytorch.losses.DiceLoss
+  mode: multiclass
+  from_logits: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: ${hyperparameters.max_lr}
+  weight_decay: 1e-4
+
+scheduler_list:
+  - scheduler:
+      _target_: torch.optim.lr_scheduler.CosineAnnealingLR
+      T_max: ${hyperparameters.epochs}
+      eta_min: 1e-7
+    interval: epoch
+    frequency: 1
+
+pl_trainer:
+  max_epochs: ${hyperparameters.epochs}
+  accelerator: auto
+  devices: 1
+  precision: "16-mixed"
+
+train_dataset:
+  _target_: pytorch_segmentation_models_trainer.dataset_loader.dataset.SegmentationDataset
+  input_csv_path: /data/train.csv
+  root_dir: /data
+  augmentation_list:
+    - _target_: albumentations.Resize
+      height: ${backbone.input_height}
+      width: ${backbone.input_width}
+    - _target_: albumentations.HorizontalFlip
+      p: 0.5
+    - _target_: albumentations.Normalize
+      mean: [0.485, 0.456, 0.406]
+      std: [0.229, 0.224, 0.225]
+    - _target_: albumentations.pytorch.ToTensorV2
+  data_loader:
+    batch_size: ${hyperparameters.batch_size}
+    num_workers: 8
+    shuffle: true
+    pin_memory: true
+    drop_last: true
+
+val_dataset:
+  _target_: pytorch_segmentation_models_trainer.dataset_loader.dataset.SegmentationDataset
+  input_csv_path: /data/val.csv
+  root_dir: /data
+  augmentation_list:
+    - _target_: albumentations.Resize
+      height: ${backbone.input_height}
+      width: ${backbone.input_width}
+    - _target_: albumentations.Normalize
+      mean: [0.485, 0.456, 0.406]
+      std: [0.229, 0.224, 0.225]
+    - _target_: albumentations.pytorch.ToTensorV2
+  data_loader:
+    batch_size: ${hyperparameters.batch_size}
+    num_workers: 8
+    shuffle: false
+    pin_memory: true
+    drop_last: false
+
+metrics:
+  - _target_: torchmetrics.JaccardIndex
+    task: multiclass
+    num_classes: ${hyperparameters.classes}
+  - _target_: torchmetrics.F1Score
+    task: multiclass
+    num_classes: ${hyperparameters.classes}

--- a/pytorch_segmentation_models_trainer/conf/examples/smp_tu_convnext.yaml
+++ b/pytorch_segmentation_models_trainer/conf/examples/smp_tu_convnext.yaml
@@ -1,0 +1,100 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Example: SMP + timm ConvNeXt-Base backbone via the "tu-" prefix
+# ──────────────────────────────────────────────────────────────────────────────
+# SMP exposes thousands of timm backbones through the "tu-" encoder prefix.
+# Replace "tu-convnext_base" with any "tu-<timm_model_name>".
+#
+# Find timm model names: python -c "import timm; print(timm.list_models())"
+# ──────────────────────────────────────────────────────────────────────────────
+
+defaults:
+  - _self_
+
+backbone:
+  name: tu-convnext_base
+  input_width: 512
+  input_height: 512
+
+hyperparameters:
+  model_name: fpn_convnext_base
+  backbone: tu-convnext_base
+  batch_size: 8
+  epochs: 50
+  max_lr: 6e-5
+  classes: 2
+
+model:
+  _target_: segmentation_models_pytorch.FPN
+  encoder_name: tu-convnext_base
+  encoder_weights: imagenet
+  in_channels: 3
+  classes: ${hyperparameters.classes}
+
+loss:
+  _target_: segmentation_models_pytorch.losses.DiceLoss
+  mode: multiclass
+  from_logits: true
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: ${hyperparameters.max_lr}
+  weight_decay: 1e-4
+
+scheduler_list:
+  - scheduler:
+      _target_: torch.optim.lr_scheduler.CosineAnnealingLR
+      T_max: ${hyperparameters.epochs}
+      eta_min: 1e-7
+    interval: epoch
+    frequency: 1
+
+pl_trainer:
+  max_epochs: ${hyperparameters.epochs}
+  accelerator: auto
+  devices: 1
+  precision: "16-mixed"
+
+train_dataset:
+  _target_: pytorch_segmentation_models_trainer.dataset_loader.dataset.SegmentationDataset
+  input_csv_path: /data/train.csv
+  root_dir: /data
+  augmentation_list:
+    - _target_: albumentations.Resize
+      height: ${backbone.input_height}
+      width: ${backbone.input_width}
+    - _target_: albumentations.HorizontalFlip
+      p: 0.5
+    - _target_: albumentations.Normalize
+      mean: [0.485, 0.456, 0.406]
+      std: [0.229, 0.224, 0.225]
+    - _target_: albumentations.pytorch.ToTensorV2
+  data_loader:
+    batch_size: ${hyperparameters.batch_size}
+    num_workers: 8
+    shuffle: true
+    pin_memory: true
+    drop_last: true
+
+val_dataset:
+  _target_: pytorch_segmentation_models_trainer.dataset_loader.dataset.SegmentationDataset
+  input_csv_path: /data/val.csv
+  root_dir: /data
+  augmentation_list:
+    - _target_: albumentations.Resize
+      height: ${backbone.input_height}
+      width: ${backbone.input_width}
+    - _target_: albumentations.Normalize
+      mean: [0.485, 0.456, 0.406]
+      std: [0.229, 0.224, 0.225]
+    - _target_: albumentations.pytorch.ToTensorV2
+  data_loader:
+    batch_size: ${hyperparameters.batch_size}
+    num_workers: 8
+    shuffle: false
+    pin_memory: true
+    drop_last: false
+
+metrics:
+  - _target_: torchmetrics.JaccardIndex
+    task: multiclass
+    num_classes: ${hyperparameters.classes}

--- a/pytorch_segmentation_models_trainer/conf/examples/vit_linear_probe.yaml
+++ b/pytorch_segmentation_models_trainer/conf/examples/vit_linear_probe.yaml
@@ -1,0 +1,100 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Example: SMP + ViT (timm) backbone – linear probe
+# ──────────────────────────────────────────────────────────────────────────────
+# Trains only the segmentation head; the entire ViT backbone is frozen.
+# Useful for fast evaluation of a pretrained representation without full
+# fine-tuning.
+#
+# strategy: linear_probe freezes all parameters then unfreezes the head.
+# ──────────────────────────────────────────────────────────────────────────────
+
+defaults:
+  - _self_
+
+backbone:
+  name: tu-vit_base_patch16_224
+  input_width: 224
+  input_height: 224
+
+hyperparameters:
+  model_name: vit_base_linear_probe
+  backbone: tu-vit_base_patch16_224
+  batch_size: 16
+  epochs: 20
+  max_lr: 1e-3
+  classes: 2
+
+model:
+  _target_: segmentation_models_pytorch.Unet
+  encoder_name: tu-vit_base_patch16_224
+  encoder_weights: imagenet
+  in_channels: 3
+  classes: ${hyperparameters.classes}
+
+fine_tuning:
+  strategy: linear_probe
+  trainable_modules: [segmentation_head]
+
+loss:
+  _target_: torch.nn.CrossEntropyLoss
+
+optimizer:
+  _target_: torch.optim.Adam
+  lr: ${hyperparameters.max_lr}
+
+scheduler_list:
+  - scheduler:
+      _target_: torch.optim.lr_scheduler.StepLR
+      step_size: 5
+      gamma: 0.5
+    interval: epoch
+    frequency: 1
+
+pl_trainer:
+  max_epochs: ${hyperparameters.epochs}
+  accelerator: auto
+  devices: 1
+  precision: "32-true"
+
+train_dataset:
+  _target_: pytorch_segmentation_models_trainer.dataset_loader.dataset.SegmentationDataset
+  input_csv_path: /data/train.csv
+  root_dir: /data
+  augmentation_list:
+    - _target_: albumentations.Resize
+      height: ${backbone.input_height}
+      width: ${backbone.input_width}
+    - _target_: albumentations.Normalize
+      mean: [0.485, 0.456, 0.406]
+      std: [0.229, 0.224, 0.225]
+    - _target_: albumentations.pytorch.ToTensorV2
+  data_loader:
+    batch_size: ${hyperparameters.batch_size}
+    num_workers: 8
+    shuffle: true
+    pin_memory: true
+    drop_last: true
+
+val_dataset:
+  _target_: pytorch_segmentation_models_trainer.dataset_loader.dataset.SegmentationDataset
+  input_csv_path: /data/val.csv
+  root_dir: /data
+  augmentation_list:
+    - _target_: albumentations.Resize
+      height: ${backbone.input_height}
+      width: ${backbone.input_width}
+    - _target_: albumentations.Normalize
+      mean: [0.485, 0.456, 0.406]
+      std: [0.229, 0.224, 0.225]
+    - _target_: albumentations.pytorch.ToTensorV2
+  data_loader:
+    batch_size: ${hyperparameters.batch_size}
+    num_workers: 8
+    shuffle: false
+    pin_memory: true
+    drop_last: false
+
+metrics:
+  - _target_: torchmetrics.JaccardIndex
+    task: multiclass
+    num_classes: ${hyperparameters.classes}

--- a/pytorch_segmentation_models_trainer/config_definitions/fine_tuning_config.py
+++ b/pytorch_segmentation_models_trainer/config_definitions/fine_tuning_config.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+ pytorch_segmentation_models_trainer
+                              -------------------
+        begin                : 2024-01-01
+        copyright            : (C) 2024 by Philipe Borba - Cartographic Engineer
+                                                            @ Brazilian Army
+        email                : philipeborba at gmail dot com
+ ***************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ****
+"""
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class LoraAdapterConfig:
+    """Configuration for LoRA (Low-Rank Adaptation) fine-tuning.
+
+    Attributes:
+        r: LoRA rank – the inner dimension of the low-rank matrices.
+            Lower values → fewer trainable parameters; higher values → more
+            expressive adapters.  Typical range: 4–64.
+        lora_alpha: Scaling factor applied to the LoRA output
+            (output = base + (lora_alpha / r) * lora_output).
+        lora_dropout: Dropout probability applied to the LoRA matrices.
+        bias: Which biases to train alongside LoRA.
+            ``"none"`` trains no biases, ``"all"`` trains all biases,
+            ``"lora_only"`` trains only the biases of LoRA layers.
+        target_modules: Names of the ``nn.Linear`` sub-modules to replace
+            with LoRA variants.  Leave empty for auto-detection based on
+            common attention-layer naming conventions (query, key, value,
+            qkv, q_proj, …).
+
+    Example::
+
+        fine_tuning:
+          strategy: lora
+          lora_config:
+            r: 16
+            lora_alpha: 32
+            lora_dropout: 0.1
+            bias: none
+            target_modules:
+              - query
+              - value
+    """
+
+    r: int = 16
+    lora_alpha: float = 32.0
+    lora_dropout: float = 0.1
+    bias: str = "none"
+    target_modules: List[str] = field(default_factory=list)
+
+
+@dataclass
+class FineTuningConfig:
+    """Top-level fine-tuning configuration.
+
+    Attributes:
+        strategy: Fine-tuning strategy.  One of:
+
+            * ``"full"`` – train all parameters (default).
+            * ``"freeze_backbone"`` – freeze encoder/backbone, train only
+              the decoder and segmentation head.
+            * ``"linear_probe"`` – freeze everything, train only the final
+              classification head.
+            * ``"lora"`` – apply PEFT LoRA adapters to attention layers;
+              requires ``lora_config`` to be set and ``peft`` to be
+              installed.
+
+        lora_config: Required when ``strategy="lora"``.
+        frozen_modules: Sub-strings used to identify modules to freeze
+            in ``freeze_backbone`` and ``linear_probe`` strategies.
+            Defaults to common backbone/encoder names.
+        trainable_modules: Sub-strings used to identify modules to keep
+            trainable.  Defaults to common decoder/head names.
+
+    Example – freeze backbone::
+
+        fine_tuning:
+          strategy: freeze_backbone
+          frozen_modules: [encoder, backbone]
+          trainable_modules: [decoder, head, segmentation_head]
+
+    Example – LoRA::
+
+        fine_tuning:
+          strategy: lora
+          lora_config:
+            r: 16
+            lora_alpha: 32
+            target_modules: [query, value]
+    """
+
+    strategy: str = "full"
+    lora_config: Optional[LoraAdapterConfig] = None
+    frozen_modules: List[str] = field(
+        default_factory=lambda: ["encoder", "backbone"]
+    )
+    trainable_modules: List[str] = field(
+        default_factory=lambda: ["decoder", "head", "segmentation_head", "neck"]
+    )

--- a/pytorch_segmentation_models_trainer/custom_models/huggingface_models.py
+++ b/pytorch_segmentation_models_trainer/custom_models/huggingface_models.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+ pytorch_segmentation_models_trainer
+                              -------------------
+        begin                : 2024-01-01
+        copyright            : (C) 2024 by Philipe Borba - Cartographic Engineer
+                                                            @ Brazilian Army
+        email                : philipeborba at gmail dot com
+ ***************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ****
+"""
+
+from typing import Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from pytorch_segmentation_models_trainer.custom_models.transformer_adapters import (
+    ModelOutputAdapter,
+)
+
+
+class HuggingFaceSegmentationWrapper(nn.Module):
+    """
+    Wraps any HuggingFace ``AutoModelForSemanticSegmentation`` so that it
+    produces a plain ``(B, num_labels, H, W)`` float tensor compatible with
+    the rest of this framework.
+
+    Key behaviours
+    --------------
+    * Loads the model via ``transformers.AutoModelForSemanticSegmentation``
+      using ``from_pretrained`` (supports both Hub model IDs and local paths).
+    * Bypasses the HuggingFace ``AutoImageProcessor`` – the pipeline's
+      existing Albumentations augmentations handle normalisation.  Users must
+      ensure the correct ``normalize_mean`` / ``normalize_std`` are set in
+      the dataset config to match the pretrained model's expectations.
+    * Output logits (typically at 1/4 input resolution for Segformer) are
+      upsampled back to the input spatial size via bilinear interpolation.
+
+    Args:
+        pretrained_model_name_or_path: HuggingFace Hub model ID or local
+            directory, e.g. ``"nvidia/segformer-b2-finetuned-ade-512-512"``.
+        num_labels: Number of output segmentation classes.  When this differs
+            from the pretrained checkpoint's head, pass
+            ``ignore_mismatched_sizes=True`` to reinitialise the head.
+        ignore_mismatched_sizes: Passed through to ``from_pretrained``; set
+            to ``True`` when fine-tuning with a different number of classes.
+        output_size: Target spatial size ``(H, W)`` for the final output.
+            Defaults to ``"input"`` (upsample to match the input resolution).
+        interpolation_mode: Interpolation used during upsampling.
+        from_pretrained_kwargs: Any extra keyword arguments forwarded to
+            ``AutoModelForSemanticSegmentation.from_pretrained``.
+
+    Example YAML config::
+
+        model:
+          _target_: pytorch_segmentation_models_trainer.custom_models.huggingface_models.HuggingFaceSegmentationWrapper
+          pretrained_model_name_or_path: nvidia/segformer-b2-finetuned-ade-512-512
+          num_labels: 2
+          ignore_mismatched_sizes: true
+    """
+
+    def __init__(
+        self,
+        pretrained_model_name_or_path: str,
+        num_labels: int,
+        ignore_mismatched_sizes: bool = False,
+        output_size: Union[str, Tuple[int, int]] = "input",
+        interpolation_mode: str = "bilinear",
+        **from_pretrained_kwargs,
+    ) -> None:
+        super().__init__()
+
+        try:
+            from transformers import AutoModelForSemanticSegmentation
+        except ImportError as e:
+            raise ImportError(
+                "The 'transformers' package is required to use "
+                "HuggingFaceSegmentationWrapper.  "
+                "Install it with:  pip install transformers"
+            ) from e
+
+        hf_model = AutoModelForSemanticSegmentation.from_pretrained(
+            pretrained_model_name_or_path,
+            num_labels=num_labels,
+            ignore_mismatched_sizes=ignore_mismatched_sizes,
+            **from_pretrained_kwargs,
+        )
+
+        self.model = ModelOutputAdapter(
+            model=hf_model,
+            output_size=output_size,
+            interpolation_mode=interpolation_mode,
+        )
+        self.num_labels = num_labels
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.model(x)

--- a/pytorch_segmentation_models_trainer/custom_models/terratorch_models.py
+++ b/pytorch_segmentation_models_trainer/custom_models/terratorch_models.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+ pytorch_segmentation_models_trainer
+                              -------------------
+        begin                : 2024-01-01
+        copyright            : (C) 2024 by Philipe Borba - Cartographic Engineer
+                                                            @ Brazilian Army
+        email                : philipeborba at gmail dot com
+ ***************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ****
+"""
+"""
+TerraTorch geospatial foundation model wrappers
+===============================================
+
+Integrates TerraTorch foundation model encoders (Prithvi, Clay, SatMAE, etc.)
+with SMP-style decoders so they produce plain ``(B, num_classes, H, W)``
+tensors compatible with this framework's training loop.
+
+TerraTorch models are typically ViT-based and operate on multi-temporal
+satellite imagery.  This wrapper handles:
+
+* Single-temporal inputs ``(B, C, H, W)`` by auto-unsqueezing to
+  ``(B, C, 1, H, W)``.
+* Multi-temporal inputs ``(B, C, T, H, W)`` passed through unchanged.
+* Dense prediction via an SMP ``UperNet``-style head or a simple linear
+  patch-projection head.
+
+Requires ``terratorch`` to be installed::
+
+    pip install terratorch
+"""
+
+from typing import List, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class _LinearSegHead(nn.Module):
+    """Simple linear head: project patch tokens → dense mask."""
+
+    def __init__(self, embed_dim: int, num_classes: int, patch_size: int) -> None:
+        super().__init__()
+        self.patch_size = patch_size
+        self.proj = nn.Conv2d(embed_dim, num_classes, kernel_size=1)
+
+    def forward(self, tokens: torch.Tensor, hw: Tuple[int, int]) -> torch.Tensor:
+        H, W = hw
+        B, N, C = tokens.shape
+        x = tokens.transpose(1, 2).reshape(B, C, H, W)
+        x = self.proj(x)
+        return F.interpolate(x, scale_factor=self.patch_size, mode="bilinear", align_corners=False)
+
+
+class TerraTorchSegmentationWrapper(nn.Module):
+    """
+    Combines a **TerraTorch** foundation model encoder with a lightweight
+    segmentation head to produce a full segmentation model.
+
+    Args:
+        backbone_name: TerraTorch model name, e.g. ``"prithvi_100M"``,
+            ``"prithvi_300M"``, ``"clay_small"``.
+        num_classes: Number of segmentation output channels.
+        in_channels: Number of spectral bands in the input image.
+        num_frames: Number of time steps.  Use ``1`` for single-temporal
+            inputs.  TerraTorch Prithvi models default to ``3`` frames but
+            can be configured for ``1``.
+        img_size: Spatial patch size expected by the backbone (e.g. 224).
+        head_type: ``"linear"`` for a simple linear projection head.
+            ``"fpn"`` attaches an SMP FPN decoder (requires multi-scale
+            feature extraction support in the backbone).
+        pretrained_path: Optional path / URL to pretrained backbone weights.
+            If ``None``, weights are random (useful for testing).
+        backbone_kwargs: Extra keyword arguments forwarded to the TerraTorch
+            model constructor.
+
+    Example YAML config::
+
+        model:
+          _target_: pytorch_segmentation_models_trainer.custom_models.terratorch_models.TerraTorchSegmentationWrapper
+          backbone_name: prithvi_100M
+          num_classes: 2
+          in_channels: 6
+          num_frames: 1
+          img_size: 224
+          head_type: linear
+          pretrained_path: /weights/prithvi_100M.pt
+    """
+
+    def __init__(
+        self,
+        backbone_name: str,
+        num_classes: int,
+        in_channels: int = 6,
+        num_frames: int = 1,
+        img_size: int = 224,
+        head_type: str = "linear",
+        pretrained_path: Optional[str] = None,
+        **backbone_kwargs,
+    ) -> None:
+        super().__init__()
+
+        try:
+            import terratorch  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "The 'terratorch' package is required to use "
+                "TerraTorchSegmentationWrapper.  "
+                "Install it with:  pip install terratorch"
+            ) from e
+
+        from terratorch.models.backbones.prithvi_model_factory import (
+            PrithviModelFactory,
+        )
+
+        factory = PrithviModelFactory()
+        self.backbone = factory.build_model(
+            task="segmentation",
+            backbone=backbone_name,
+            backbone_pretrained_cfg_overlay={
+                "file": pretrained_path,
+            }
+            if pretrained_path
+            else None,
+            in_channels=in_channels,
+            num_frames=num_frames,
+            img_size=img_size,
+            **backbone_kwargs,
+        )
+
+        self.num_frames = num_frames
+        self.num_classes = num_classes
+        embed_dim: int = getattr(self.backbone, "embed_dim", 768)
+        patch_size: int = getattr(self.backbone, "patch_size", 16)
+
+        head_type = head_type.lower()
+        if head_type == "linear":
+            self.head = _LinearSegHead(
+                embed_dim=embed_dim,
+                num_classes=num_classes,
+                patch_size=patch_size,
+            )
+        elif head_type == "fpn":
+            try:
+                import segmentation_models_pytorch as smp
+                from segmentation_models_pytorch.base import SegmentationHead
+            except ImportError as exc:
+                raise ImportError(
+                    "segmentation-models-pytorch is required for head_type='fpn'."
+                ) from exc
+            # FPN decoder expects encoder_channels list
+            encoder_channels = [0, embed_dim // 4, embed_dim // 2, embed_dim, embed_dim]
+            self.decoder = smp.decoders.fpn.decoder.FPNDecoder(
+                encoder_channels=encoder_channels,
+                encoder_depth=4,
+                pyramid_channels=256,
+                segmentation_channels=128,
+                dropout=0.2,
+                merge_policy="add",
+            )
+            self.head = SegmentationHead(
+                in_channels=128,
+                out_channels=num_classes,
+                activation=None,
+                kernel_size=3,
+                upsampling=patch_size,
+            )
+        else:
+            raise ValueError(
+                f"Unsupported head_type='{head_type}'. Choose 'linear' or 'fpn'."
+            )
+
+    def _prepare_input(self, x: torch.Tensor) -> torch.Tensor:
+        """Accept ``(B, C, H, W)`` and expand to ``(B, C, T, H, W)``."""
+        if x.ndim == 4:
+            x = x.unsqueeze(2)  # (B, C, 1, H, W)
+        return x
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self._prepare_input(x)
+        B, C, T, H, W = x.shape
+
+        features = self.backbone(x)
+
+        # TerraTorch returns dict or tensor depending on version/config
+        if isinstance(features, dict):
+            tokens = features.get("last_hidden_state", features.get("features"))
+        elif isinstance(features, (list, tuple)):
+            tokens = features[-1]
+        else:
+            tokens = features
+
+        if tokens.ndim == 3:
+            # (B, N, embed_dim) patch tokens → pass to linear head
+            h_patches = H // getattr(self.backbone, "patch_size", 16)
+            w_patches = W // getattr(self.backbone, "patch_size", 16)
+            return self.head(tokens, (h_patches, w_patches))
+        else:
+            # (B, C, H', W') feature map → pass directly to head
+            return self.head(tokens)

--- a/pytorch_segmentation_models_trainer/custom_models/timm_models.py
+++ b/pytorch_segmentation_models_trainer/custom_models/timm_models.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+ pytorch_segmentation_models_trainer
+                              -------------------
+        begin                : 2024-01-01
+        copyright            : (C) 2024 by Philipe Borba - Cartographic Engineer
+                                                            @ Brazilian Army
+        email                : philipeborba at gmail dot com
+ ***************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ****
+"""
+"""
+timm-based segmentation models
+================================
+
+**Recommended path (zero new code):**
+Most timm backbones are already available inside
+``segmentation_models_pytorch`` via the ``"tu-"`` encoder prefix::
+
+    model:
+      _target_: segmentation_models_pytorch.Unet
+      encoder_name: tu-convnext_base   # any timm model name prefixed with tu-
+      encoder_weights: imagenet
+      in_channels: 3
+      classes: 2
+
+Use :class:`TimmEncoderWithSMPDecoder` only when you need a timm backbone
+that is *not* registered as an SMP encoder, or when you want fine-grained
+control over the decoder architecture.
+"""
+
+from typing import List, Optional
+
+import torch
+import torch.nn as nn
+
+
+class TimmEncoderWithSMPDecoder(nn.Module):
+    """
+    Combines a **timm** feature-extraction backbone with an
+    **SMP** decoder to produce a full segmentation model.
+
+    The timm encoder is created with ``features_only=True`` so it returns
+    multi-scale feature maps.  The feature channel sizes are read from
+    ``encoder.feature_info`` and forwarded to the chosen SMP decoder.
+
+    Supported decoders (``decoder_type``):
+        * ``"unet"``        – :class:`segmentation_models_pytorch.UnetDecoder`
+        * ``"fpn"``         – :class:`segmentation_models_pytorch.FPNDecoder`
+        * ``"pan"``         – :class:`segmentation_models_pytorch.PANDecoder`
+        * ``"pspnet"``      – :class:`segmentation_models_pytorch.PSPDecoder`
+        * ``"deeplabv3"``   – :class:`segmentation_models_pytorch.DeepLabV3Decoder`
+        * ``"deeplabv3plus"`` – :class:`segmentation_models_pytorch.DeepLabV3PlusDecoder`
+
+    Args:
+        timm_model_name: Any timm model name, e.g. ``"convnext_base"``,
+            ``"vit_base_patch16_224"``.
+        num_classes: Number of segmentation output channels.
+        decoder_type: SMP decoder to attach.  Defaults to ``"unet"``.
+        in_channels: Number of input image channels.  Defaults to 3.
+        pretrained: Load timm ImageNet pretrained weights.  Defaults to
+            ``True``.
+        decoder_channels: Output channel sizes for each decoder stage (only
+            used by UNet decoder).  Defaults to ``(256, 128, 64, 32, 16)``.
+        upsampling: Final upsampling factor applied by the segmentation head.
+
+    Example YAML config::
+
+        model:
+          _target_: pytorch_segmentation_models_trainer.custom_models.timm_models.TimmEncoderWithSMPDecoder
+          timm_model_name: convnext_base
+          num_classes: 2
+          decoder_type: fpn
+          pretrained: true
+    """
+
+    def __init__(
+        self,
+        timm_model_name: str,
+        num_classes: int,
+        decoder_type: str = "unet",
+        in_channels: int = 3,
+        pretrained: bool = True,
+        decoder_channels: tuple = (256, 128, 64, 32, 16),
+        upsampling: int = 4,
+    ) -> None:
+        super().__init__()
+
+        try:
+            import timm
+        except ImportError as e:
+            raise ImportError(
+                "The 'timm' package is required to use TimmEncoderWithSMPDecoder.  "
+                "Install it with:  pip install timm"
+            ) from e
+
+        try:
+            import segmentation_models_pytorch as smp
+            from segmentation_models_pytorch.base import SegmentationHead
+        except ImportError as e:
+            raise ImportError(
+                "The 'segmentation_models_pytorch' package is required.  "
+                "Install it with:  pip install segmentation-models-pytorch"
+            ) from e
+
+        # Build encoder
+        self.encoder = timm.create_model(
+            timm_model_name,
+            pretrained=pretrained,
+            features_only=True,
+            in_chans=in_channels,
+        )
+        encoder_channels: List[int] = [
+            fi["num_chs"] for fi in self.encoder.feature_info
+        ]
+        # Prepend 0 to follow SMP convention (first entry = stem/input)
+        encoder_channels_smp = [0] + encoder_channels
+
+        decoder_type = decoder_type.lower()
+
+        if decoder_type == "unet":
+            self.decoder = smp.decoders.unet.decoder.UnetDecoder(
+                encoder_channels=encoder_channels_smp,
+                decoder_channels=decoder_channels[: len(encoder_channels)],
+                n_blocks=len(encoder_channels),
+                use_batchnorm=True,
+                attention_type=None,
+            )
+            head_in_channels = decoder_channels[len(encoder_channels) - 1]
+        elif decoder_type == "fpn":
+            self.decoder = smp.decoders.fpn.decoder.FPNDecoder(
+                encoder_channels=encoder_channels_smp,
+                encoder_depth=len(encoder_channels),
+                pyramid_channels=256,
+                segmentation_channels=128,
+                dropout=0.2,
+                merge_policy="add",
+            )
+            head_in_channels = 128
+        elif decoder_type == "pan":
+            self.decoder = smp.decoders.pan.decoder.PANDecoder(
+                encoder_channels=encoder_channels_smp,
+                encoder_depth=len(encoder_channels),
+                upscale_factor=1,
+            )
+            head_in_channels = 32
+        else:
+            raise ValueError(
+                f"Unsupported decoder_type='{decoder_type}'. "
+                f"Choose from: 'unet', 'fpn', 'pan'."
+            )
+
+        self.segmentation_head = SegmentationHead(
+            in_channels=head_in_channels,
+            out_channels=num_classes,
+            activation=None,
+            kernel_size=3,
+            upsampling=upsampling,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        features = self.encoder(x)
+        # SMP decoders expect the feature list prepended with the input tensor
+        decoder_output = self.decoder(*([x] + features))
+        return self.segmentation_head(decoder_output)

--- a/pytorch_segmentation_models_trainer/custom_models/transformer_adapters.py
+++ b/pytorch_segmentation_models_trainer/custom_models/transformer_adapters.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+ pytorch_segmentation_models_trainer
+                              -------------------
+        begin                : 2024-01-01
+        copyright            : (C) 2024 by Philipe Borba - Cartographic Engineer
+                                                            @ Brazilian Army
+        email                : philipeborba at gmail dot com
+ ***************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ****
+"""
+
+from typing import Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class ModelOutputAdapter(nn.Module):
+    """
+    Wraps any segmentation model and normalises its output to a plain
+    ``(B, C, H, W)`` float tensor.
+
+    Handles the three most common non-standard output shapes produced by
+    HuggingFace, TerraTorch and plain-timm models:
+
+    * **Dataclass / NamedTuple with ``.logits``** – e.g.
+      ``transformers.SegmentationModelOutput``.
+    * **Dict** – keys tried in order: ``output_key``, ``"logits"``,
+      ``"out"``, ``"pred"``.  Pass ``output_key`` to force a specific key.
+    * **Tuple / list** – the first element is used.
+    * **Plain tensor** – returned as-is (no copy).
+
+    After extracting the tensor the adapter optionally upsamples it to match
+    the spatial size of the input, which is required for models like
+    Segformer that output at 1/4 resolution.
+
+    Args:
+        model: The underlying ``nn.Module`` to wrap.
+        output_key: Force a specific dict key when the model returns a dict.
+            Ignored for other output types.
+        output_size: Target spatial size ``(H, W)`` for the output tensor.
+            Pass ``None`` (default) to skip upsampling, or the string
+            ``"input"`` to automatically upsample to the spatial dimensions
+            of the *input* tensor passed to ``forward``.
+        interpolation_mode: Interpolation mode forwarded to
+            ``torch.nn.functional.interpolate``.  Defaults to
+            ``"bilinear"``.
+        align_corners: Passed to ``F.interpolate`` when ``interpolation_mode``
+            is ``"bilinear"`` or ``"bicubic"``.  Defaults to ``False``.
+    """
+
+    _DICT_KEY_PRIORITY = ("logits", "out", "pred", "output", "masks")
+
+    def __init__(
+        self,
+        model: nn.Module,
+        output_key: Optional[str] = None,
+        output_size: Optional[Union[str, Tuple[int, int]]] = "input",
+        interpolation_mode: str = "bilinear",
+        align_corners: bool = False,
+    ) -> None:
+        super().__init__()
+        self.model = model
+        self.output_key = output_key
+        self.output_size = output_size
+        self.interpolation_mode = interpolation_mode
+        self.align_corners = align_corners
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _extract_tensor(self, raw_output) -> torch.Tensor:
+        """Convert any model output type to a plain tensor."""
+        if isinstance(raw_output, torch.Tensor):
+            return raw_output
+
+        # Dataclass / object with .logits (HuggingFace pattern)
+        if hasattr(raw_output, "logits") and isinstance(
+            raw_output.logits, torch.Tensor
+        ):
+            return raw_output.logits
+
+        # Dict-like
+        if isinstance(raw_output, dict):
+            # Try user-specified key first
+            if self.output_key is not None:
+                if self.output_key in raw_output:
+                    val = raw_output[self.output_key]
+                    if isinstance(val, torch.Tensor):
+                        return val
+                raise KeyError(
+                    f"ModelOutputAdapter: output_key '{self.output_key}' not found "
+                    f"in model output dict.  Available keys: {list(raw_output.keys())}"
+                )
+            # Auto-detect key
+            for key in self._DICT_KEY_PRIORITY:
+                if key in raw_output and isinstance(raw_output[key], torch.Tensor):
+                    return raw_output[key]
+            raise KeyError(
+                f"ModelOutputAdapter: could not find a tensor in the model output "
+                f"dict.  Tried keys {self._DICT_KEY_PRIORITY}.  "
+                f"Available keys: {list(raw_output.keys())}.  "
+                f"Pass output_key='<your_key>' to the adapter."
+            )
+
+        # Tuple / list – take first element
+        if isinstance(raw_output, (tuple, list)):
+            first = raw_output[0]
+            if isinstance(first, torch.Tensor):
+                return first
+            raise TypeError(
+                f"ModelOutputAdapter: first element of tuple/list output is "
+                f"{type(first).__name__}, expected torch.Tensor."
+            )
+
+        raise TypeError(
+            f"ModelOutputAdapter: unsupported output type '{type(raw_output).__name__}'. "
+            f"Expected torch.Tensor, dict, tuple/list, or an object with a "
+            f"'.logits' attribute."
+        )
+
+    def _maybe_upsample(
+        self, tensor: torch.Tensor, input_tensor: torch.Tensor
+    ) -> torch.Tensor:
+        """Upsample *tensor* if self.output_size demands it."""
+        if self.output_size is None:
+            return tensor
+
+        if self.output_size == "input":
+            target_h, target_w = input_tensor.shape[-2], input_tensor.shape[-1]
+        else:
+            target_h, target_w = self.output_size
+
+        out_h, out_w = tensor.shape[-2], tensor.shape[-1]
+        if out_h == target_h and out_w == target_w:
+            return tensor
+
+        kwargs = {}
+        if self.interpolation_mode in ("bilinear", "bicubic"):
+            kwargs["align_corners"] = self.align_corners
+
+        return F.interpolate(
+            tensor.float(),
+            size=(target_h, target_w),
+            mode=self.interpolation_mode,
+            **kwargs,
+        )
+
+    # ------------------------------------------------------------------
+    # Forward
+    # ------------------------------------------------------------------
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        raw = self.model(x)
+        tensor = self._extract_tensor(raw)
+        tensor = self._maybe_upsample(tensor, x)
+        return tensor

--- a/pytorch_segmentation_models_trainer/fine_tuning/__init__.py
+++ b/pytorch_segmentation_models_trainer/fine_tuning/__init__.py
@@ -1,0 +1,11 @@
+from pytorch_segmentation_models_trainer.fine_tuning.lora_utils import (
+    apply_fine_tuning_strategy,
+    freeze_modules_by_name,
+    get_trainable_parameter_count,
+)
+
+__all__ = [
+    "apply_fine_tuning_strategy",
+    "freeze_modules_by_name",
+    "get_trainable_parameter_count",
+]

--- a/pytorch_segmentation_models_trainer/fine_tuning/lora_utils.py
+++ b/pytorch_segmentation_models_trainer/fine_tuning/lora_utils.py
@@ -1,0 +1,308 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+ pytorch_segmentation_models_trainer
+                              -------------------
+        begin                : 2024-01-01
+        copyright            : (C) 2024 by Philipe Borba - Cartographic Engineer
+                                                            @ Brazilian Army
+        email                : philipeborba at gmail dot com
+ ***************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ****
+"""
+"""
+Fine-tuning strategies for segmentation models
+===============================================
+
+Provides four strategies, all applied by :func:`apply_fine_tuning_strategy`:
+
+``"full"``
+    All parameters are trainable (default, no-op).
+
+``"freeze_backbone"``
+    Freeze everything except the decoder / segmentation head.  Works for
+    SMP, HuggingFace, TerraTorch, and plain timm wrappers by matching module
+    names that contain ``"decoder"`` or ``"head"`` (configurable via
+    ``trainable_module_names``).
+
+``"linear_probe"``
+    Freeze the entire model then unfreeze only the final layer whose name
+    contains ``"head"`` or ``"segmentation_head"`` (configurable).
+
+``"lora"``
+    Apply PEFT LoRA adapters to the attention layers of the model.
+    Requires ``peft`` to be installed (``pip install peft``).
+
+All strategies log a parameter count summary via Python's ``logging`` module.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import torch
+import torch.nn as nn
+
+logger = logging.getLogger(__name__)
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Public helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+_DEFAULT_BACKBONE_NAMES = ("encoder", "backbone", "model.encoder", "model.backbone")
+_DEFAULT_TRAINABLE_NAMES = ("decoder", "head", "segmentation_head", "neck")
+
+
+def freeze_modules_by_name(
+    model: nn.Module,
+    frozen_names: tuple = _DEFAULT_BACKBONE_NAMES,
+    trainable_names: tuple = _DEFAULT_TRAINABLE_NAMES,
+) -> nn.Module:
+    """
+    Freeze parameters whose module name contains any string in *frozen_names*,
+    then unfreeze those whose name contains any string in *trainable_names*.
+
+    This two-pass approach means ``trainable_names`` always wins, so a module
+    like ``"backbone.decoder"`` would be unfrozen even if ``"backbone"`` is in
+    *frozen_names*.
+
+    Args:
+        model: The model to modify in-place.
+        frozen_names: Sub-strings that mark modules to freeze.
+        trainable_names: Sub-strings that mark modules to keep trainable.
+
+    Returns:
+        The modified model (same object, in-place operation).
+    """
+    # Pass 1: freeze everything that matches frozen_names
+    for name, param in model.named_parameters():
+        if any(fn in name for fn in frozen_names):
+            param.requires_grad = False
+
+    # Pass 2: unfreeze anything that matches trainable_names
+    for name, param in model.named_parameters():
+        if any(tn in name for tn in trainable_names):
+            param.requires_grad = True
+
+    return model
+
+
+def get_trainable_parameter_count(model: nn.Module) -> Dict[str, int]:
+    """Return a dict with ``trainable``, ``frozen``, and ``total`` counts."""
+    trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    total = sum(p.numel() for p in model.parameters())
+    return {"trainable": trainable, "frozen": total - trainable, "total": total}
+
+
+def _log_param_summary(model: nn.Module, strategy: str) -> None:
+    counts = get_trainable_parameter_count(model)
+    pct = 100.0 * counts["trainable"] / max(counts["total"], 1)
+    logger.info(
+        "Fine-tuning strategy='%s' | trainable=%s / %s (%.1f%%)",
+        strategy,
+        f"{counts['trainable']:,}",
+        f"{counts['total']:,}",
+        pct,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Strategy implementations
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _apply_full(model: nn.Module, cfg: Any) -> nn.Module:
+    for param in model.parameters():
+        param.requires_grad = True
+    return model
+
+
+def _apply_freeze_backbone(model: nn.Module, cfg: Any) -> nn.Module:
+    frozen = tuple(getattr(cfg, "frozen_modules", None) or _DEFAULT_BACKBONE_NAMES)
+    trainable = tuple(
+        getattr(cfg, "trainable_modules", None) or _DEFAULT_TRAINABLE_NAMES
+    )
+    # Start with all params frozen
+    for param in model.parameters():
+        param.requires_grad = False
+    # Unfreeze trainable parts
+    for name, param in model.named_parameters():
+        if any(tn in name for tn in trainable):
+            param.requires_grad = True
+        # If no backbone names match at all (e.g. a model with unusual naming),
+        # also unfreeze anything NOT matching frozen names
+        elif not any(fn in name for fn in frozen):
+            param.requires_grad = True
+    return model
+
+
+def _apply_linear_probe(model: nn.Module, cfg: Any) -> nn.Module:
+    # Freeze everything first
+    for param in model.parameters():
+        param.requires_grad = False
+
+    trainable_keywords = tuple(
+        getattr(cfg, "trainable_modules", None) or ("head", "segmentation_head", "classifier")
+    )
+    unfrozen_any = False
+    for name, param in model.named_parameters():
+        if any(kw in name for kw in trainable_keywords):
+            param.requires_grad = True
+            unfrozen_any = True
+
+    if not unfrozen_any:
+        logger.warning(
+            "linear_probe strategy: no parameters matched trainable_modules=%s. "
+            "All parameters remain frozen.  Set trainable_modules in fine_tuning "
+            "config to match your model's head layer names.",
+            trainable_keywords,
+        )
+    return model
+
+
+def _apply_lora(model: nn.Module, cfg: Any) -> nn.Module:
+    try:
+        from peft import LoraConfig, TaskType, get_peft_model
+    except ImportError as e:
+        raise ImportError(
+            "The 'peft' package is required for LoRA fine-tuning.  "
+            "Install it with:  pip install peft"
+        ) from e
+
+    lora_cfg = getattr(cfg, "lora_config", None)
+    if lora_cfg is None:
+        raise ValueError(
+            "strategy='lora' requires a 'lora_config' block in fine_tuning config."
+        )
+
+    r = int(getattr(lora_cfg, "r", 16))
+    lora_alpha = float(getattr(lora_cfg, "lora_alpha", 32.0))
+    lora_dropout = float(getattr(lora_cfg, "lora_dropout", 0.1))
+    bias = str(getattr(lora_cfg, "bias", "none"))
+    target_modules = list(getattr(lora_cfg, "target_modules", []))
+
+    if not target_modules:
+        # Auto-detect: collect names of all nn.Linear layers inside attention blocks
+        target_modules = _auto_detect_attention_linears(model)
+        if not target_modules:
+            raise ValueError(
+                "LoRA: could not auto-detect attention linear layers.  "
+                "Please set lora_config.target_modules explicitly, e.g. "
+                '["query", "value"] for HuggingFace or ["qkv"] for ViT models.'
+            )
+        logger.info("LoRA: auto-detected target_modules=%s", target_modules)
+
+    peft_config = LoraConfig(
+        task_type=TaskType.FEATURE_EXTRACTION,
+        r=r,
+        lora_alpha=lora_alpha,
+        lora_dropout=lora_dropout,
+        bias=bias,
+        target_modules=target_modules,
+    )
+
+    model = get_peft_model(model, peft_config)
+    return model
+
+
+def _auto_detect_attention_linears(model: nn.Module) -> List[str]:
+    """
+    Heuristically collect unique short names of ``nn.Linear`` layers that
+    appear to belong to attention blocks (name contains common attention
+    keywords).
+    """
+    attention_keywords = ("query", "key", "value", "q_proj", "k_proj", "v_proj", "qkv", "attn")
+    found = set()
+    for name, module in model.named_modules():
+        if isinstance(module, nn.Linear):
+            short = name.split(".")[-1]
+            if any(kw in name.lower() for kw in attention_keywords):
+                found.add(short)
+    return sorted(found)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Public entry point
+# ──────────────────────────────────────────────────────────────────────────────
+
+_STRATEGY_MAP = {
+    "full": _apply_full,
+    "freeze_backbone": _apply_freeze_backbone,
+    "linear_probe": _apply_linear_probe,
+    "lora": _apply_lora,
+}
+
+
+def apply_fine_tuning_strategy(model: nn.Module, cfg: Any) -> nn.Module:
+    """
+    Apply the fine-tuning strategy described in *cfg* to *model*.
+
+    Args:
+        model: The model to modify.
+        cfg: An OmegaConf config node (or any object) with at minimum a
+            ``strategy`` attribute.  Supported strategies and their config
+            keys are documented in the module docstring.
+
+    Returns:
+        The (potentially wrapped) model.
+
+    Example config::
+
+        fine_tuning:
+          strategy: lora
+          lora_config:
+            r: 16
+            lora_alpha: 32
+            lora_dropout: 0.1
+            bias: none
+            target_modules: [query, value]
+    """
+    strategy = str(getattr(cfg, "strategy", "full")).lower()
+
+    if strategy not in _STRATEGY_MAP:
+        raise ValueError(
+            f"Unknown fine_tuning strategy='{strategy}'.  "
+            f"Choose from: {list(_STRATEGY_MAP.keys())}"
+        )
+
+    model = _STRATEGY_MAP[strategy](model, cfg)
+    _log_param_summary(model, strategy)
+    return model
+
+
+def merge_lora_weights(model: nn.Module) -> nn.Module:
+    """
+    Merge LoRA adapter weights into the base model and return a plain
+    ``nn.Module`` without PEFT wrappers.  Call this before deployment /
+    inference to remove the PEFT overhead.
+
+    Args:
+        model: A PEFT-wrapped model (``PeftModel``).
+
+    Returns:
+        The merged base model.
+    """
+    try:
+        from peft import PeftModel
+    except ImportError:
+        return model  # peft not installed, nothing to do
+
+    if isinstance(model, PeftModel):
+        model = model.merge_and_unload()
+        logger.info("LoRA weights merged and PEFT wrapper removed.")
+    return model
+
+
+def is_peft_model(model: nn.Module) -> bool:
+    """Return ``True`` if *model* is wrapped with a PEFT adapter."""
+    try:
+        from peft import PeftModel
+
+        return isinstance(model, PeftModel)
+    except ImportError:
+        return False

--- a/pytorch_segmentation_models_trainer/model_loader/model.py
+++ b/pytorch_segmentation_models_trainer/model_loader/model.py
@@ -30,6 +30,10 @@ from torch.utils.data import DataLoader
 from typing import Any, Union, Dict, Tuple
 from pytorch_segmentation_models_trainer.utils.model_utils import replace_activation
 from pytorch_segmentation_models_trainer.custom_losses.base_loss import MultiLoss
+from pytorch_segmentation_models_trainer.fine_tuning.lora_utils import (
+    apply_fine_tuning_strategy,
+    is_peft_model,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -253,6 +257,8 @@ class Model(pl.LightningModule):
                 self.cfg.replace_model_activation.new_activation, _recursive_=False
             )
             replace_activation(model, old_activation, new_activation)
+        if "fine_tuning" in self.cfg:
+            model = apply_fine_tuning_strategy(model, self.cfg.fine_tuning)
         return model
 
     def get_gpu_augmentations(self, augmentation_list):
@@ -316,12 +322,56 @@ class Model(pl.LightningModule):
         )
 
     def set_encoder_trainable(self, trainable=False):
-        """Freezes or unfreezes the model encoder."""
-        for child in self.model.encoder.children():
-            for param in child.parameters():
-                param.requires_grad = trainable
+        """Freeze or unfreeze the encoder/backbone of the model.
+
+        Works for SMP models (``self.model.encoder``), HuggingFace wrappers
+        and any model whose backbone is accessible via common attribute names
+        (``encoder``, ``backbone``, ``model.encoder``, ``model.backbone``).
+        Falls back to a name-based search when no direct attribute is found.
+        """
+        backbone_attrs = ("encoder", "backbone")
+        found = False
+
+        # Try direct attribute access first (SMP, custom models)
+        target = self.model
+        # Unwrap one level for wrappers like ModelOutputAdapter / HF wrapper
+        inner = getattr(self.model, "model", None)
+        if inner is not None:
+            inner2 = getattr(inner, "model", None)
+            candidates = [self.model] + ([inner] if inner else []) + ([inner2] if inner2 else [])
+        else:
+            candidates = [self.model]
+
+        for obj in candidates:
+            for attr in backbone_attrs:
+                backbone = getattr(obj, attr, None)
+                if backbone is not None:
+                    for param in backbone.parameters():
+                        param.requires_grad = trainable
+                    logger.info(
+                        "set_encoder_trainable: set '%s.%s' trainable=%s",
+                        type(obj).__name__, attr, trainable,
+                    )
+                    found = True
+                    break
+            if found:
+                break
+
+        if not found:
+            # Generic fallback: use parameter name matching
+            backbone_keywords = ("encoder", "backbone", "patch_embed", "blocks")
+            head_keywords = ("decoder", "head", "segmentation_head", "neck", "classifier")
+            for name, param in self.model.named_parameters():
+                is_backbone = any(kw in name for kw in backbone_keywords)
+                is_head = any(kw in name for kw in head_keywords)
+                if is_backbone and not is_head:
+                    param.requires_grad = trainable
+            logger.info(
+                "set_encoder_trainable: applied keyword-based freeze (trainable=%s).",
+                trainable,
+            )
+
         print(f"\nEncoder weights set to trainable={trainable}\n")
-        return
 
     def forward(self, x):
         return self.model(x)
@@ -483,9 +533,26 @@ class Model(pl.LightningModule):
             loss = self.loss_function(predicted_masks, masks)
             return loss, {}, {}
 
+    def _unpack_batch(self, batch):
+        """Extract (images, masks) from a batch dict.
+
+        Supports configurable key names via ``cfg.image_key`` /
+        ``cfg.mask_key`` (defaults: ``"image"`` / ``"mask"``).
+        Extra keys in the batch dict are silently ignored.
+        """
+        image_key = getattr(self.cfg, "image_key", "image")
+        mask_key = getattr(self.cfg, "mask_key", "mask")
+        if isinstance(batch, dict):
+            images = batch[image_key]
+            masks = batch[mask_key]
+        else:
+            # Fallback for tuple/list batches
+            images, masks = batch[0], batch[1]
+        return images, masks
+
     def training_step(self, batch, batch_idx):
         """Training step - now supports both simple and compound losses."""
-        images, masks = batch.values()
+        images, masks = self._unpack_batch(batch)
         masks = masks.long()
         predicted_masks = self(images)
 
@@ -527,21 +594,18 @@ class Model(pl.LightningModule):
 
         # Compute and log metrics - automatically prefixed with train/
         if hasattr(self, "train_metrics"):
-            preds_for_metrics = (
-                predicted_masks.squeeze(1)
-                if predicted_masks.ndim == 4 and predicted_masks.shape[1] == 1
-                else predicted_masks
-            )
-            metrics = self.train_metrics(preds_for_metrics, masks)
-            self.log_dict(
-                metrics, on_step=True, on_epoch=True, prog_bar=False, sync_dist=True
-            )
+            preds_for_metrics = self._prepare_preds_for_metrics(predicted_masks)
+            if preds_for_metrics is not None:
+                metrics = self.train_metrics(preds_for_metrics, masks)
+                self.log_dict(
+                    metrics, on_step=True, on_epoch=True, prog_bar=False, sync_dist=True
+                )
 
         return loss
 
     def validation_step(self, batch, batch_idx):
         """Validation step - now supports both simple and compound losses."""
-        images, masks = batch.values()
+        images, masks = self._unpack_batch(batch)
         masks = masks.long()
         predicted_masks = self(images)
 
@@ -583,15 +647,12 @@ class Model(pl.LightningModule):
 
         # Compute and log metrics - automatically prefixed with val/
         if hasattr(self, "val_metrics"):
-            preds_for_metrics = (
-                predicted_masks.squeeze(1)
-                if predicted_masks.ndim == 4 and predicted_masks.shape[1] == 1
-                else predicted_masks
-            )
-            metrics = self.val_metrics(preds_for_metrics, masks)
-            self.log_dict(
-                metrics, on_step=False, on_epoch=True, prog_bar=False, sync_dist=True
-            )
+            preds_for_metrics = self._prepare_preds_for_metrics(predicted_masks)
+            if preds_for_metrics is not None:
+                metrics = self.val_metrics(preds_for_metrics, masks)
+                self.log_dict(
+                    metrics, on_step=False, on_epoch=True, prog_bar=False, sync_dist=True
+                )
 
         return loss
 
@@ -604,6 +665,24 @@ class Model(pl.LightningModule):
                 "normalize_losses", True  # Default to True
             )
         return self.should_normalize
+
+    def _prepare_preds_for_metrics(self, predicted_masks):
+        """Safely prepare predictions for torchmetrics.
+
+        Squeezes the channel dim for binary models (shape B,1,H,W → B,H,W).
+        Returns ``None`` if *predicted_masks* is not a tensor so that metric
+        logging is silently skipped rather than crashing.
+        """
+        if not isinstance(predicted_masks, torch.Tensor):
+            logger.warning(
+                "Model output is not a torch.Tensor (%s); skipping metrics. "
+                "Wrap your model with ModelOutputAdapter to fix this.",
+                type(predicted_masks).__name__,
+            )
+            return None
+        if predicted_masks.ndim == 4 and predicted_masks.shape[1] == 1:
+            return predicted_masks.squeeze(1)
+        return predicted_masks
 
     # Removed training_epoch_end and validation_epoch_end
     # Lightning 2.0+ automatically aggregates metrics

--- a/pytorch_segmentation_models_trainer/predict.py
+++ b/pytorch_segmentation_models_trainer/predict.py
@@ -36,6 +36,10 @@ from pytorch_segmentation_models_trainer.tools.polygonization.polygonizer import
     TemplatePolygonizerProcessor,
 )
 from pytorch_segmentation_models_trainer.utils.os_utils import import_module_from_cfg
+from pytorch_segmentation_models_trainer.fine_tuning.lora_utils import (
+    is_peft_model,
+    merge_lora_weights,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +66,15 @@ def instantiate_model_from_checkpoint(cfg: DictConfig) -> torch.nn.Module:
         weights_only=False,
     )
     model = pl_model.model
+
+    # Merge LoRA adapter weights (if any) before inference so that the model
+    # runs without the PEFT wrapper overhead.  Set merge_lora=false in config
+    # to keep adapters active (e.g. for continued fine-tuning).
+    should_merge = not bool(getattr(cfg, "keep_lora_adapters", False))
+    if should_merge and is_peft_model(model):
+        logger.info("Merging LoRA adapter weights before inference.")
+        model = merge_lora_weights(model)
+
     model.to(cfg.device)
     model.eval()
     return model

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,16 @@ seaborn==0.13.2
 scikit-learn>=1.3.2
 scikit-image>=0.21.0
 typing_extensions>=4.0.0
+
+# ── Transformer / foundation-model support (optional) ──────────────────────
+# Install the libraries you need:
+#   pip install transformers          # HuggingFace models (Segformer, Mask2Former…)
+#   pip install peft                  # LoRA / adapter fine-tuning
+#   pip install timm                  # timm standalone encoder support
+#   pip install terratorch            # TerraTorch geospatial foundation models
+#
+# Commented out to keep the base install lightweight:
+# transformers>=4.30.0
+# peft>=0.6.0
+# timm>=0.9.0
+# terratorch>=0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,14 +46,22 @@ scikit-image>=0.21.0
 typing_extensions>=4.0.0
 
 # ── Transformer / foundation-model support (optional) ──────────────────────
-# Install the libraries you need:
-#   pip install transformers          # HuggingFace models (Segformer, Mask2Former…)
-#   pip install peft                  # LoRA / adapter fine-tuning
-#   pip install timm                  # timm standalone encoder support
-#   pip install terratorch            # TerraTorch geospatial foundation models
+# These libraries are NOT installed by default to keep the base footprint small.
 #
-# Commented out to keep the base install lightweight:
+# Install all at once via the pip extras group:
+#   pip install "pytorch_segmentation_models_trainer[transformers]"
+#
+# Or individually:
+#   pip install transformers>=4.30.0  # HuggingFace models (Segformer, Mask2Former…)
+#   pip install peft>=0.6.0           # LoRA / adapter fine-tuning
+#   pip install timm>=0.9.0           # timm standalone encoder support
+#
+# TerraTorch (geospatial foundation models – Prithvi, Clay, SatMAE) is not yet
+# on PyPI; install directly from source:
+#   pip install terratorch
+#
+# Uncomment below only if you want these pinned in a requirements-based install:
 # transformers>=4.30.0
 # peft>=0.6.0
 # timm>=0.9.0
-# terratorch>=0.1.0
+# terratorch

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,26 @@ except:
     DEP_LINKS = []
 
 # What packages are optional?
-EXTRAS = {"tests": ["pytest", "scikit-image", "parameterized"]}
+EXTRAS = {
+    # Run the test suite
+    "tests": ["pytest", "scikit-image", "parameterized"],
+    # Transformer / foundation-model support
+    #   pip install pytorch_segmentation_models_trainer[transformers]
+    "transformers": [
+        "transformers>=4.30.0",  # HuggingFace models (Segformer, Mask2Former, …)
+        "peft>=0.6.0",           # LoRA / adapter fine-tuning
+        "timm>=0.9.0",           # timm standalone encoder support
+        # terratorch is not on PyPI – install manually: pip install terratorch
+    ],
+    # Everything at once
+    #   pip install pytorch_segmentation_models_trainer[all]
+    "all": [
+        "pytest", "scikit-image", "parameterized",
+        "transformers>=4.30.0",
+        "peft>=0.6.0",
+        "timm>=0.9.0",
+    ],
+}
 
 # Import the README and use it as the long-description.
 # Note: this will only work if 'README.md' is present in your MANIFEST.in file!

--- a/tests/test_fine_tuning.py
+++ b/tests/test_fine_tuning.py
@@ -1,0 +1,286 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for fine-tuning strategies (Phase 5).
+
+Covers freeze_backbone, linear_probe, lora (with peft mock), and the
+generic set_encoder_trainable replacement in Model.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+import torch.nn as nn
+
+from pytorch_segmentation_models_trainer.fine_tuning.lora_utils import (
+    apply_fine_tuning_strategy,
+    freeze_modules_by_name,
+    get_trainable_parameter_count,
+    is_peft_model,
+    merge_lora_weights,
+)
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+class _SimpleSegModel(nn.Module):
+    """Minimal model with encoder + decoder + head."""
+    def __init__(self):
+        super().__init__()
+        self.encoder = nn.Sequential(
+            nn.Conv2d(3, 16, 3, padding=1),
+            nn.ReLU(),
+        )
+        self.decoder = nn.Sequential(
+            nn.Conv2d(16, 8, 3, padding=1),
+            nn.ReLU(),
+        )
+        self.segmentation_head = nn.Conv2d(8, 2, 1)
+
+    def forward(self, x):
+        x = self.encoder(x)
+        x = self.decoder(x)
+        return self.segmentation_head(x)
+
+
+class _AttentionModel(nn.Module):
+    """Minimal model with attention-like naming (query/value projections)."""
+    def __init__(self):
+        super().__init__()
+        self.encoder = nn.ModuleDict({
+            "query": nn.Linear(64, 64),
+            "key":   nn.Linear(64, 64),
+            "value": nn.Linear(64, 64),
+        })
+        self.segmentation_head = nn.Linear(64, 2)
+
+    def forward(self, x):
+        q = self.encoder["query"](x)
+        k = self.encoder["key"](x)
+        v = self.encoder["value"](x)
+        return self.segmentation_head(q + k + v)
+
+
+def _cfg(**kwargs):
+    return SimpleNamespace(**kwargs)
+
+
+# ─── Tests: get_trainable_parameter_count ─────────────────────────────────────
+
+class TestGetTrainableParameterCount:
+    def test_all_trainable(self):
+        model = _SimpleSegModel()
+        counts = get_trainable_parameter_count(model)
+        assert counts["trainable"] == counts["total"]
+        assert counts["frozen"] == 0
+
+    def test_all_frozen(self):
+        model = _SimpleSegModel()
+        for p in model.parameters():
+            p.requires_grad = False
+        counts = get_trainable_parameter_count(model)
+        assert counts["trainable"] == 0
+        assert counts["frozen"] == counts["total"]
+
+
+# ─── Tests: freeze_modules_by_name ────────────────────────────────────────────
+
+class TestFreezeModulesByName:
+    def test_encoder_frozen(self):
+        model = _SimpleSegModel()
+        freeze_modules_by_name(model, frozen_names=("encoder",), trainable_names=("decoder", "head"))
+        for name, param in model.named_parameters():
+            if "encoder" in name:
+                assert not param.requires_grad, f"{name} should be frozen"
+
+    def test_head_remains_trainable(self):
+        model = _SimpleSegModel()
+        freeze_modules_by_name(model, frozen_names=("encoder",), trainable_names=("decoder", "head"))
+        for name, param in model.named_parameters():
+            if "segmentation_head" in name or "decoder" in name:
+                assert param.requires_grad, f"{name} should be trainable"
+
+    def test_trainable_wins_over_frozen(self):
+        """A module whose name matches both frozen and trainable should be trainable."""
+        model = _SimpleSegModel()
+        # 'encoder.0' matches both frozen=("encoder",) and trainable=("encoder.0",)
+        freeze_modules_by_name(
+            model,
+            frozen_names=("encoder",),
+            trainable_names=("encoder.0",),
+        )
+        for name, param in model.named_parameters():
+            if "encoder.0" in name:
+                assert param.requires_grad
+
+
+# ─── Tests: apply_fine_tuning_strategy ────────────────────────────────────────
+
+class TestFullStrategy:
+    def test_all_params_trainable(self):
+        model = _SimpleSegModel()
+        for p in model.parameters():
+            p.requires_grad = False
+        result = apply_fine_tuning_strategy(model, _cfg(strategy="full"))
+        counts = get_trainable_parameter_count(result)
+        assert counts["trainable"] == counts["total"]
+
+
+class TestFreezeBackboneStrategy:
+    def test_encoder_frozen_decoder_trainable(self):
+        model = _SimpleSegModel()
+        cfg = _cfg(
+            strategy="freeze_backbone",
+            frozen_modules=["encoder"],
+            trainable_modules=["decoder", "segmentation_head"],
+        )
+        result = apply_fine_tuning_strategy(model, cfg)
+        for name, param in result.named_parameters():
+            if "encoder" in name:
+                assert not param.requires_grad, f"{name} should be frozen"
+            if "decoder" in name or "segmentation_head" in name:
+                assert param.requires_grad, f"{name} should be trainable"
+
+    def test_reduces_trainable_count(self):
+        model = _SimpleSegModel()
+        total_before = get_trainable_parameter_count(model)["total"]
+        cfg = _cfg(
+            strategy="freeze_backbone",
+            frozen_modules=["encoder"],
+            trainable_modules=["decoder", "segmentation_head"],
+        )
+        result = apply_fine_tuning_strategy(model, cfg)
+        counts = get_trainable_parameter_count(result)
+        assert counts["trainable"] < total_before
+
+
+class TestLinearProbeStrategy:
+    def test_only_head_trainable(self):
+        model = _SimpleSegModel()
+        cfg = _cfg(
+            strategy="linear_probe",
+            trainable_modules=["segmentation_head"],
+        )
+        result = apply_fine_tuning_strategy(model, cfg)
+        for name, param in result.named_parameters():
+            if "segmentation_head" in name:
+                assert param.requires_grad, f"{name} should be trainable"
+            else:
+                assert not param.requires_grad, f"{name} should be frozen"
+
+    def test_warns_when_no_head_matched(self, caplog):
+        import logging
+        model = _SimpleSegModel()
+        cfg = _cfg(
+            strategy="linear_probe",
+            trainable_modules=["nonexistent_layer"],
+        )
+        with caplog.at_level(logging.WARNING):
+            apply_fine_tuning_strategy(model, cfg)
+        assert "no parameters matched" in caplog.text.lower()
+
+
+class TestLoraStrategy:
+    def test_lora_requires_peft(self):
+        with patch.dict("sys.modules", {"peft": None}):
+            model = _SimpleSegModel()
+            cfg = _cfg(
+                strategy="lora",
+                lora_config=_cfg(r=4, lora_alpha=8, lora_dropout=0.0, bias="none", target_modules=[]),
+            )
+            with pytest.raises(ImportError, match="peft"):
+                apply_fine_tuning_strategy(model, cfg)
+
+    def test_lora_requires_lora_config(self):
+        try:
+            import peft  # noqa: F401
+        except ImportError:
+            pytest.skip("peft not installed")
+        model = _SimpleSegModel()
+        cfg = _cfg(strategy="lora", lora_config=None)
+        with pytest.raises(ValueError, match="lora_config"):
+            apply_fine_tuning_strategy(model, cfg)
+
+    def test_lora_applied_to_attention_model(self):
+        try:
+            from peft import PeftModel
+        except ImportError:
+            pytest.skip("peft not installed")
+        model = _AttentionModel()
+        cfg = _cfg(
+            strategy="lora",
+            lora_config=_cfg(
+                r=4,
+                lora_alpha=8,
+                lora_dropout=0.0,
+                bias="none",
+                target_modules=["query", "value"],
+            ),
+        )
+        result = apply_fine_tuning_strategy(model, cfg)
+        assert is_peft_model(result)
+
+    def test_lora_reduces_trainable_params(self):
+        try:
+            from peft import PeftModel
+        except ImportError:
+            pytest.skip("peft not installed")
+        model = _AttentionModel()
+        total_before = get_trainable_parameter_count(model)["total"]
+        cfg = _cfg(
+            strategy="lora",
+            lora_config=_cfg(
+                r=4,
+                lora_alpha=8,
+                lora_dropout=0.0,
+                bias="none",
+                target_modules=["query", "value"],
+            ),
+        )
+        result = apply_fine_tuning_strategy(model, cfg)
+        counts = get_trainable_parameter_count(result)
+        assert counts["trainable"] < total_before
+
+    def test_merge_lora_weights(self):
+        try:
+            from peft import PeftModel
+        except ImportError:
+            pytest.skip("peft not installed")
+        model = _AttentionModel()
+        cfg = _cfg(
+            strategy="lora",
+            lora_config=_cfg(
+                r=4,
+                lora_alpha=8,
+                lora_dropout=0.0,
+                bias="none",
+                target_modules=["query", "value"],
+            ),
+        )
+        lora_model = apply_fine_tuning_strategy(model, cfg)
+        merged = merge_lora_weights(lora_model)
+        # After merge, should no longer be a PeftModel
+        assert not is_peft_model(merged)
+        # Forward pass should still work
+        x = torch.randn(2, 64)
+        out = merged(x)
+        assert out.shape == (2, 2)
+
+
+class TestUnknownStrategy:
+    def test_raises_value_error(self):
+        model = _SimpleSegModel()
+        with pytest.raises(ValueError, match="Unknown fine_tuning strategy"):
+            apply_fine_tuning_strategy(model, _cfg(strategy="unknown_strategy"))
+
+
+# ─── Tests: is_peft_model / merge_lora_weights ────────────────────────────────
+
+class TestPeftHelpers:
+    def test_is_peft_model_false_for_plain_model(self):
+        assert not is_peft_model(_SimpleSegModel())
+
+    def test_merge_lora_weights_no_op_for_plain_model(self):
+        model = _SimpleSegModel()
+        result = merge_lora_weights(model)
+        assert result is model  # same object returned

--- a/tests/test_huggingface_models.py
+++ b/tests/test_huggingface_models.py
@@ -4,6 +4,9 @@ Tests for HuggingFaceSegmentationWrapper (Phase 2).
 
 All HuggingFace network calls are mocked so these tests run offline
 without downloading any weights.
+
+Skipped automatically when 'transformers' is not installed.  Install it
+with:  pip install pytorch_segmentation_models_trainer[transformers]
 """
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -11,6 +14,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 import torch.nn as nn
+
+# Skip the entire module when transformers is not installed so that the main
+# CI job (which does not install optional deps) reports SKIPPED instead of ERROR.
+pytest.importorskip(
+    "transformers",
+    reason="transformers not installed – run: pip install '.[transformers]'",
+)
 
 from pytorch_segmentation_models_trainer.custom_models.huggingface_models import (
     HuggingFaceSegmentationWrapper,

--- a/tests/test_huggingface_models.py
+++ b/tests/test_huggingface_models.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for HuggingFaceSegmentationWrapper (Phase 2).
+
+All HuggingFace network calls are mocked so these tests run offline
+without downloading any weights.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+import torch.nn as nn
+
+from pytorch_segmentation_models_trainer.custom_models.huggingface_models import (
+    HuggingFaceSegmentationWrapper,
+)
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+B, H, W = 2, 128, 128
+
+
+def _make_fake_hf_model(num_labels: int, out_h: int = None, out_w: int = None):
+    """Return a tiny nn.Module that mimics a HuggingFace segmentation model output."""
+    _out_h = out_h or H // 4
+    _out_w = out_w or W // 4
+
+    class _FakeHFModel(nn.Module):
+        def forward(self, pixel_values=None, **kwargs):
+            logits = torch.randn(B, num_labels, _out_h, _out_w)
+            return SimpleNamespace(logits=logits)
+
+    return _FakeHFModel()
+
+
+def _patch_auto_model(fake_model):
+    """Context manager that patches AutoModelForSemanticSegmentation.from_pretrained."""
+    return patch(
+        "transformers.AutoModelForSemanticSegmentation.from_pretrained",
+        return_value=fake_model,
+    )
+
+
+# ─── Tests ───────────────────────────────────────────────────────────────────
+
+class TestHuggingFaceSegmentationWrapper:
+    def test_instantiation(self):
+        fake = _make_fake_hf_model(num_labels=2)
+        with _patch_auto_model(fake):
+            wrapper = HuggingFaceSegmentationWrapper(
+                pretrained_model_name_or_path="fake/model",
+                num_labels=2,
+            )
+        assert isinstance(wrapper, nn.Module)
+        assert wrapper.num_labels == 2
+
+    def test_forward_returns_tensor(self):
+        fake = _make_fake_hf_model(num_labels=2)
+        with _patch_auto_model(fake):
+            wrapper = HuggingFaceSegmentationWrapper(
+                pretrained_model_name_or_path="fake/model",
+                num_labels=2,
+            )
+        x = torch.randn(B, 3, H, W)
+        out = wrapper(x)
+        assert isinstance(out, torch.Tensor)
+
+    def test_output_upsampled_to_input_size(self):
+        """Segformer outputs H/4 – wrapper must upsample to H."""
+        fake = _make_fake_hf_model(num_labels=2, out_h=H // 4, out_w=W // 4)
+        with _patch_auto_model(fake):
+            wrapper = HuggingFaceSegmentationWrapper(
+                pretrained_model_name_or_path="fake/model",
+                num_labels=2,
+                output_size="input",
+            )
+        x = torch.randn(B, 3, H, W)
+        out = wrapper(x)
+        assert out.shape == (B, 2, H, W)
+
+    def test_output_shape_num_labels(self):
+        for num_labels in [2, 5, 19]:
+            fake = _make_fake_hf_model(num_labels=num_labels)
+            with _patch_auto_model(fake):
+                wrapper = HuggingFaceSegmentationWrapper(
+                    pretrained_model_name_or_path="fake/model",
+                    num_labels=num_labels,
+                )
+            x = torch.randn(B, 3, H, W)
+            out = wrapper(x)
+            assert out.shape[1] == num_labels, f"Failed for num_labels={num_labels}"
+
+    def test_output_is_plain_tensor_not_dataclass(self):
+        fake = _make_fake_hf_model(num_labels=2)
+        with _patch_auto_model(fake):
+            wrapper = HuggingFaceSegmentationWrapper(
+                pretrained_model_name_or_path="fake/model",
+                num_labels=2,
+            )
+        x = torch.randn(B, 3, H, W)
+        out = wrapper(x)
+        assert type(out) is torch.Tensor
+
+    def test_import_error_when_transformers_missing(self):
+        with patch.dict("sys.modules", {"transformers": None}):
+            with pytest.raises(ImportError, match="transformers"):
+                HuggingFaceSegmentationWrapper(
+                    pretrained_model_name_or_path="fake/model",
+                    num_labels=2,
+                )
+
+    def test_from_pretrained_called_with_correct_args(self):
+        fake = _make_fake_hf_model(num_labels=3)
+        with patch(
+            "transformers.AutoModelForSemanticSegmentation.from_pretrained",
+            return_value=fake,
+        ) as mock_fp:
+            HuggingFaceSegmentationWrapper(
+                pretrained_model_name_or_path="some/path",
+                num_labels=3,
+                ignore_mismatched_sizes=True,
+            )
+            mock_fp.assert_called_once_with(
+                "some/path",
+                num_labels=3,
+                ignore_mismatched_sizes=True,
+            )

--- a/tests/test_inference_pipeline.py
+++ b/tests/test_inference_pipeline.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the inference pipeline (Phase 7).
+
+Validates LoRA merge-before-inference, model extraction from checkpoints,
+and that is_peft_model / merge_lora_weights behave correctly.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+import torch.nn as nn
+
+from pytorch_segmentation_models_trainer.fine_tuning.lora_utils import (
+    is_peft_model,
+    merge_lora_weights,
+)
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+class _SimpleModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc = nn.Linear(4, 2)
+
+    def forward(self, x):
+        return self.fc(x)
+
+
+# ─── Tests: LoRA helpers ──────────────────────────────────────────────────────
+
+class TestLoraInferencePrepHelpers:
+    def test_is_peft_model_false_without_peft(self):
+        with patch.dict("sys.modules", {"peft": None}):
+            model = _SimpleModel()
+            assert not is_peft_model(model)
+
+    def test_is_peft_model_false_for_plain_model(self):
+        assert not is_peft_model(_SimpleModel())
+
+    def test_merge_lora_weights_returns_same_model_when_not_peft(self):
+        model = _SimpleModel()
+        result = merge_lora_weights(model)
+        assert result is model
+
+    def test_merge_lora_weights_noop_without_peft(self):
+        with patch.dict("sys.modules", {"peft": None}):
+            model = _SimpleModel()
+            result = merge_lora_weights(model)
+            assert result is model
+
+
+class TestMergeLoraBeforeInference:
+    def test_merge_called_when_is_peft_model(self):
+        """Verify the predict.py path calls merge_and_unload on a PeftModel."""
+        # Simulate a PeftModel by monkey-patching is_peft_model
+        model = _SimpleModel()
+        model.merge_and_unload = MagicMock(return_value=model)
+
+        with patch(
+            "pytorch_segmentation_models_trainer.fine_tuning.lora_utils.is_peft_model",
+            return_value=True,
+        ), patch(
+            "pytorch_segmentation_models_trainer.fine_tuning.lora_utils.PeftModel",
+            create=True,
+        ):
+            result = merge_lora_weights(model)
+            model.merge_and_unload.assert_called_once()
+
+
+# ─── Tests: inference model eval mode ─────────────────────────────────────────
+
+class TestInstantiateModelFromCheckpoint:
+    def test_model_is_in_eval_mode_after_load(self, tmp_path):
+        """
+        Smoke-test: load a fake checkpoint and confirm model.eval() was called.
+        We mock the entire checkpoint load chain to avoid real file I/O.
+        """
+        from omegaconf import OmegaConf
+
+        cfg = OmegaConf.create({
+            "checkpoint_path": str(tmp_path / "fake.ckpt"),
+            "pl_model": {
+                "_target_": "pytorch_segmentation_models_trainer.model_loader.model.Model",
+            },
+            "pl_trainer": {"devices": [0]},
+            "device": "cpu",
+            "model": {
+                "_target_": "segmentation_models_pytorch.Unet",
+                "encoder_name": "resnet18",
+                "encoder_weights": None,
+                "in_channels": 3,
+                "classes": 2,
+            },
+            "loss": {"_target_": "torch.nn.CrossEntropyLoss"},
+            "hyperparameters": {"batch_size": 2, "devices": 1, "accelerator": "cpu"},
+            "keep_lora_adapters": False,
+        })
+
+        inner_model = _SimpleModel()
+        fake_pl_model = MagicMock()
+        fake_pl_model.model = inner_model
+
+        with patch(
+            "pytorch_segmentation_models_trainer.predict.import_module_from_cfg"
+        ) as mock_import, patch(
+            "pytorch_segmentation_models_trainer.predict.is_peft_model",
+            return_value=False,
+        ):
+            mock_cls = MagicMock()
+            mock_cls.load_from_checkpoint.return_value = fake_pl_model
+            mock_import.return_value = mock_cls
+
+            from pytorch_segmentation_models_trainer.predict import (
+                instantiate_model_from_checkpoint,
+            )
+
+            # Patch cuda to be unavailable so map_location = "cpu"
+            with patch("torch.cuda.is_available", return_value=False):
+                result = instantiate_model_from_checkpoint(cfg)
+
+        # The returned model should be the inner model in eval mode
+        assert not result.training
+
+    def test_lora_merge_called_when_peft_model(self, tmp_path):
+        from omegaconf import OmegaConf
+
+        cfg = OmegaConf.create({
+            "checkpoint_path": str(tmp_path / "fake.ckpt"),
+            "pl_model": {"_target_": "pytorch_segmentation_models_trainer.model_loader.model.Model"},
+            "pl_trainer": {"devices": [0]},
+            "device": "cpu",
+            "model": {
+                "_target_": "segmentation_models_pytorch.Unet",
+                "encoder_name": "resnet18",
+                "encoder_weights": None,
+                "in_channels": 3,
+                "classes": 2,
+            },
+            "loss": {"_target_": "torch.nn.CrossEntropyLoss"},
+            "hyperparameters": {"batch_size": 2, "devices": 1, "accelerator": "cpu"},
+            "keep_lora_adapters": False,
+        })
+
+        inner_model = _SimpleModel()
+        inner_model.merge_and_unload = MagicMock(return_value=inner_model)
+        fake_pl_model = MagicMock()
+        fake_pl_model.model = inner_model
+
+        with patch(
+            "pytorch_segmentation_models_trainer.predict.import_module_from_cfg"
+        ) as mock_import, patch(
+            "pytorch_segmentation_models_trainer.predict.is_peft_model",
+            return_value=True,
+        ), patch(
+            "pytorch_segmentation_models_trainer.predict.merge_lora_weights",
+            return_value=inner_model,
+        ) as mock_merge, patch(
+            "torch.cuda.is_available", return_value=False
+        ):
+            mock_cls = MagicMock()
+            mock_cls.load_from_checkpoint.return_value = fake_pl_model
+            mock_import.return_value = mock_cls
+
+            from pytorch_segmentation_models_trainer.predict import (
+                instantiate_model_from_checkpoint,
+            )
+            instantiate_model_from_checkpoint(cfg)
+
+        mock_merge.assert_called_once()

--- a/tests/test_model_training_step.py
+++ b/tests/test_model_training_step.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the hardened training loop (Phase 6).
+
+Validates batch unpacking, configurable keys, extra key tolerance,
+and end-to-end training/validation steps with a lightweight SMP model.
+"""
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+import torch.nn as nn
+from omegaconf import OmegaConf
+
+from pytorch_segmentation_models_trainer.model_loader.model import Model
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+B, H, W, CLASSES = 2, 64, 64, 2
+
+
+def _make_cfg(image_key="image", mask_key="mask", **extra):
+    cfg = OmegaConf.create({
+        "model": {
+            "_target_": "segmentation_models_pytorch.Unet",
+            "encoder_name": "resnet18",
+            "encoder_weights": None,
+            "in_channels": 3,
+            "classes": CLASSES,
+        },
+        "loss": {
+            "_target_": "torch.nn.CrossEntropyLoss",
+        },
+        "image_key": image_key,
+        "mask_key": mask_key,
+        "hyperparameters": {
+            "batch_size": B,
+            "devices": 1,
+            "accelerator": "cpu",
+        },
+        **extra,
+    })
+    return cfg
+
+
+def _make_model(cfg=None):
+    cfg = cfg or _make_cfg()
+    return Model(cfg, inference_mode=False)
+
+
+def _make_batch(image_key="image", mask_key="mask", extra_keys=None):
+    batch = {
+        image_key: torch.randn(B, 3, H, W),
+        mask_key: torch.zeros(B, H, W, dtype=torch.long),
+    }
+    if extra_keys:
+        for k in extra_keys:
+            batch[k] = torch.zeros(B)
+    return batch
+
+
+# ─── Tests: _unpack_batch ─────────────────────────────────────────────────────
+
+class TestUnpackBatch:
+    def test_default_keys(self):
+        model = _make_model()
+        batch = _make_batch()
+        images, masks = model._unpack_batch(batch)
+        assert images.shape == (B, 3, H, W)
+        assert masks.shape == (B, H, W)
+
+    def test_custom_image_key(self):
+        cfg = _make_cfg(image_key="pixel_values", mask_key="label")
+        model = _make_model(cfg)
+        batch = _make_batch(image_key="pixel_values", mask_key="label")
+        images, masks = model._unpack_batch(batch)
+        assert images.shape == (B, 3, H, W)
+
+    def test_extra_keys_ignored(self):
+        model = _make_model()
+        batch = _make_batch(extra_keys=["filename", "metadata"])
+        images, masks = model._unpack_batch(batch)
+        assert images.shape == (B, 3, H, W)
+        assert masks.shape == (B, H, W)
+
+    def test_tuple_batch_fallback(self):
+        model = _make_model()
+        images_t = torch.randn(B, 3, H, W)
+        masks_t = torch.zeros(B, H, W, dtype=torch.long)
+        images, masks = model._unpack_batch((images_t, masks_t))
+        assert torch.equal(images, images_t)
+
+    def test_missing_key_raises(self):
+        model = _make_model()
+        batch = {"wrong_key": torch.randn(B, 3, H, W)}
+        with pytest.raises(KeyError):
+            model._unpack_batch(batch)
+
+
+# ─── Tests: _prepare_preds_for_metrics ────────────────────────────────────────
+
+class TestPreparePreds:
+    def test_squeezes_binary(self):
+        model = _make_model()
+        preds = torch.randn(B, 1, H, W)
+        result = model._prepare_preds_for_metrics(preds)
+        assert result.shape == (B, H, W)
+
+    def test_multiclass_unchanged(self):
+        model = _make_model()
+        preds = torch.randn(B, CLASSES, H, W)
+        result = model._prepare_preds_for_metrics(preds)
+        assert result.shape == (B, CLASSES, H, W)
+
+    def test_non_tensor_returns_none(self, caplog):
+        model = _make_model()
+        with caplog.at_level(logging.WARNING):
+            result = model._prepare_preds_for_metrics({"logits": torch.randn(B, CLASSES, H, W)})
+        assert result is None
+        assert "not a torch.tensor" in caplog.text.lower()
+
+
+# ─── Tests: training_step / validation_step end-to-end ───────────────────────
+
+class TestTrainingStepEndToEnd:
+    def test_training_step_returns_scalar_loss(self):
+        model = _make_model()
+        batch = _make_batch()
+        loss = model.training_step(batch, 0)
+        assert isinstance(loss, torch.Tensor)
+        assert loss.ndim == 0
+
+    def test_validation_step_returns_scalar_loss(self):
+        model = _make_model()
+        batch = _make_batch()
+        # Mock the log method to avoid PL trainer requirement
+        model.log = MagicMock()
+        loss = model.validation_step(batch, 0)
+        assert isinstance(loss, torch.Tensor)
+        assert loss.ndim == 0
+
+    def test_training_step_with_extra_batch_keys(self):
+        model = _make_model()
+        batch = _make_batch(extra_keys=["filename"])
+        model.log = MagicMock()
+        loss = model.training_step(batch, 0)
+        assert isinstance(loss, torch.Tensor)
+
+    def test_training_step_custom_keys(self):
+        cfg = _make_cfg(image_key="pixel_values", mask_key="label")
+        model = _make_model(cfg)
+        batch = _make_batch(image_key="pixel_values", mask_key="label")
+        model.log = MagicMock()
+        loss = model.training_step(batch, 0)
+        assert isinstance(loss, torch.Tensor)
+
+
+# ─── Tests: set_encoder_trainable ─────────────────────────────────────────────
+
+class TestSetEncoderTrainable:
+    def test_smp_model_encoder_can_be_frozen(self):
+        model = _make_model()
+        model.set_encoder_trainable(trainable=False)
+        # At least some encoder params should be frozen
+        encoder_params = [
+            p for n, p in model.model.named_parameters() if "encoder" in n
+        ]
+        assert any(not p.requires_grad for p in encoder_params)
+
+    def test_smp_model_encoder_can_be_unfrozen(self):
+        model = _make_model()
+        # Freeze first
+        for p in model.model.parameters():
+            p.requires_grad = False
+        # Then unfreeze encoder
+        model.set_encoder_trainable(trainable=True)
+        encoder_params = [
+            p for n, p in model.model.named_parameters() if "encoder" in n
+        ]
+        assert any(p.requires_grad for p in encoder_params)

--- a/tests/test_terratorch_models.py
+++ b/tests/test_terratorch_models.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for TerraTorchSegmentationWrapper (Phase 4).
+
+TerraTorch is mocked so these tests run without installing terratorch.
+The _prepare_input helper and head wiring are tested with a fake backbone.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+import torch.nn as nn
+
+
+# ─── Helpers ───────────────────────────────────────────────────────��─────────
+
+B, C_IN, H, W = 2, 6, 64, 64
+EMBED_DIM = 32
+PATCH_SIZE = 16
+NUM_TOKENS = (H // PATCH_SIZE) * (W // PATCH_SIZE)  # 16
+
+
+def _make_fake_terratorch_module():
+    """A tiny nn.Module that mimics a TerraTorch backbone returning patch tokens."""
+    class _FakeBackbone(nn.Module):
+        embed_dim = EMBED_DIM
+        patch_size = PATCH_SIZE
+
+        def forward(self, x):
+            # x: (B, C, T, H, W)
+            B = x.shape[0]
+            H_p = x.shape[-2] // PATCH_SIZE
+            W_p = x.shape[-1] // PATCH_SIZE
+            tokens = torch.randn(B, H_p * W_p, EMBED_DIM)
+            return tokens
+
+    return _FakeBackbone()
+
+
+def _make_fake_factory(backbone):
+    factory = MagicMock()
+    factory.build_model.return_value = backbone
+    return factory
+
+
+# ─── Import under mock ──────────────────��─────────────────────────────────────
+
+def _build_wrapper(backbone, num_classes=2, head_type="linear"):
+    """Build TerraTorchSegmentationWrapper with a mocked factory."""
+    fake_factory = _make_fake_factory(backbone)
+    with patch.dict("sys.modules", {
+        "terratorch": MagicMock(),
+        "terratorch.models": MagicMock(),
+        "terratorch.models.backbones": MagicMock(),
+        "terratorch.models.backbones.prithvi_model_factory": MagicMock(
+            PrithviModelFactory=MagicMock(return_value=fake_factory)
+        ),
+    }):
+        from pytorch_segmentation_models_trainer.custom_models.terratorch_models import (
+            TerraTorchSegmentationWrapper,
+        )
+        wrapper = TerraTorchSegmentationWrapper(
+            backbone_name="prithvi_100M",
+            num_classes=num_classes,
+            in_channels=C_IN,
+            num_frames=1,
+            img_size=H,
+            head_type=head_type,
+            pretrained_path=None,
+        )
+    # Replace the backbone with our fake one directly
+    wrapper.backbone = backbone
+    return wrapper
+
+
+# ─── Tests ─────────────────────────────────────────────────────────────��─────
+
+class TestTerraTorchWrapper:
+    def test_import_error_when_terratorch_missing(self):
+        with patch.dict("sys.modules", {"terratorch": None}):
+            with pytest.raises(ImportError, match="terratorch"):
+                from pytorch_segmentation_models_trainer.custom_models.terratorch_models import (
+                    TerraTorchSegmentationWrapper,
+                )
+                TerraTorchSegmentationWrapper(
+                    backbone_name="prithvi_100M",
+                    num_classes=2,
+                    in_channels=6,
+                    num_frames=1,
+                    img_size=64,
+                    head_type="linear",
+                )
+
+    def test_prepare_input_4d_to_5d(self):
+        backbone = _make_fake_terratorch_module()
+        wrapper = _build_wrapper(backbone)
+        x = torch.randn(B, C_IN, H, W)
+        x5d = wrapper._prepare_input(x)
+        assert x5d.ndim == 5
+        assert x5d.shape == (B, C_IN, 1, H, W)
+
+    def test_prepare_input_5d_unchanged(self):
+        backbone = _make_fake_terratorch_module()
+        wrapper = _build_wrapper(backbone)
+        x = torch.randn(B, C_IN, 2, H, W)
+        x5d = wrapper._prepare_input(x)
+        assert x5d.shape == (B, C_IN, 2, H, W)
+
+    def test_forward_single_temporal(self):
+        backbone = _make_fake_terratorch_module()
+        wrapper = _build_wrapper(backbone, num_classes=2, head_type="linear")
+        x = torch.randn(B, C_IN, H, W)
+        with torch.no_grad():
+            out = wrapper(x)
+        assert isinstance(out, torch.Tensor)
+        assert out.shape[0] == B
+        assert out.shape[1] == 2
+
+    def test_forward_output_spatial_size(self):
+        backbone = _make_fake_terratorch_module()
+        wrapper = _build_wrapper(backbone, num_classes=2, head_type="linear")
+        x = torch.randn(B, C_IN, H, W)
+        with torch.no_grad():
+            out = wrapper(x)
+        assert out.shape[-2] == H
+        assert out.shape[-1] == W
+
+    def test_unsupported_head_type_raises(self):
+        # head_type="fpn" requires SMP – just validate the error message
+        backbone = _make_fake_terratorch_module()
+        with pytest.raises((ValueError, ImportError)):
+            _build_wrapper(backbone, head_type="invalid_head")

--- a/tests/test_timm_models.py
+++ b/tests/test_timm_models.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for TimmEncoderWithSMPDecoder (Phase 3).
+
+Uses a real tiny timm model (resnet18) to validate the full forward pass
+on CPU with small tensors.  No pretrained weights are downloaded
+(pretrained=False).
+"""
+import pytest
+import torch
+
+try:
+    import timm  # noqa: F401
+    TIMM_AVAILABLE = True
+except ImportError:
+    TIMM_AVAILABLE = False
+
+try:
+    import segmentation_models_pytorch  # noqa: F401
+    SMP_AVAILABLE = True
+except ImportError:
+    SMP_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(
+    not (TIMM_AVAILABLE and SMP_AVAILABLE),
+    reason="timm and segmentation-models-pytorch are required",
+)
+
+from pytorch_segmentation_models_trainer.custom_models.timm_models import (
+    TimmEncoderWithSMPDecoder,
+)
+
+B, H, W = 2, 128, 128
+
+
+class TestTimmEncoderWithSMPDecoder:
+    def test_unet_decoder_instantiation(self):
+        model = TimmEncoderWithSMPDecoder(
+            timm_model_name="resnet18",
+            num_classes=2,
+            decoder_type="unet",
+            pretrained=False,
+        )
+        assert model is not None
+
+    def test_unet_forward_shape(self):
+        model = TimmEncoderWithSMPDecoder(
+            timm_model_name="resnet18",
+            num_classes=2,
+            decoder_type="unet",
+            pretrained=False,
+        )
+        model.eval()
+        x = torch.randn(B, 3, H, W)
+        with torch.no_grad():
+            out = model(x)
+        assert out.shape[0] == B
+        assert out.shape[1] == 2
+
+    def test_fpn_decoder_instantiation(self):
+        model = TimmEncoderWithSMPDecoder(
+            timm_model_name="resnet18",
+            num_classes=3,
+            decoder_type="fpn",
+            pretrained=False,
+        )
+        assert model is not None
+
+    def test_fpn_forward_shape(self):
+        model = TimmEncoderWithSMPDecoder(
+            timm_model_name="resnet18",
+            num_classes=3,
+            decoder_type="fpn",
+            pretrained=False,
+        )
+        model.eval()
+        x = torch.randn(B, 3, H, W)
+        with torch.no_grad():
+            out = model(x)
+        assert out.shape[0] == B
+        assert out.shape[1] == 3
+
+    def test_unsupported_decoder_raises(self):
+        with pytest.raises(ValueError, match="Unsupported decoder_type"):
+            TimmEncoderWithSMPDecoder(
+                timm_model_name="resnet18",
+                num_classes=2,
+                decoder_type="deeplabv3",  # not supported in wrapper
+                pretrained=False,
+            )
+
+    def test_custom_in_channels(self):
+        model = TimmEncoderWithSMPDecoder(
+            timm_model_name="resnet18",
+            num_classes=2,
+            decoder_type="unet",
+            in_channels=6,
+            pretrained=False,
+        )
+        model.eval()
+        x = torch.randn(B, 6, H, W)
+        with torch.no_grad():
+            out = model(x)
+        assert out.shape[0] == B
+        assert out.shape[1] == 2
+
+    def test_import_error_when_timm_missing(self):
+        from unittest.mock import patch
+        with patch.dict("sys.modules", {"timm": None}):
+            with pytest.raises(ImportError, match="timm"):
+                TimmEncoderWithSMPDecoder(
+                    timm_model_name="resnet18",
+                    num_classes=2,
+                    pretrained=False,
+                )
+
+
+class TestSMPTuPrefix:
+    """Validate that the SMP 'tu-' prefix path works end-to-end."""
+
+    def test_smp_unet_with_tu_resnet18(self):
+        import segmentation_models_pytorch as smp
+        model = smp.Unet(
+            encoder_name="tu-resnet18",
+            encoder_weights=None,
+            in_channels=3,
+            classes=2,
+        )
+        model.eval()
+        x = torch.randn(B, 3, H, W)
+        with torch.no_grad():
+            out = model(x)
+        assert out.shape == (B, 2, H, W)

--- a/tests/test_transformer_adapters.py
+++ b/tests/test_transformer_adapters.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for ModelOutputAdapter (Phase 1).
+All tests run on CPU with random tensors – no pretrained weights needed.
+"""
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from pytorch_segmentation_models_trainer.custom_models.transformer_adapters import (
+    ModelOutputAdapter,
+)
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+B, C, H, W = 2, 4, 64, 64
+
+
+def _random_input():
+    return torch.randn(B, 3, H, W)
+
+
+def _random_output(h=H, w=W):
+    return torch.randn(B, C, h, w)
+
+
+class _TensorModel(nn.Module):
+    """Returns a plain tensor."""
+    def forward(self, x):
+        return _random_output()
+
+
+class _DictOutModel(nn.Module):
+    """Returns a dict with a configurable key."""
+    def __init__(self, key="logits"):
+        super().__init__()
+        self.key = key
+
+    def forward(self, x):
+        return {self.key: _random_output()}
+
+
+class _DataclassModel(nn.Module):
+    """Returns a NamedTuple/dataclass-like object with .logits."""
+    def forward(self, x):
+        return SimpleNamespace(logits=_random_output())
+
+
+class _TupleModel(nn.Module):
+    """Returns a tuple (tensor, aux)."""
+    def forward(self, x):
+        return (_random_output(), torch.zeros(1))
+
+
+class _LowResModel(nn.Module):
+    """Returns logits at 1/4 resolution (e.g. Segformer)."""
+    def forward(self, x):
+        h, w = x.shape[-2] // 4, x.shape[-1] // 4
+        return _random_output(h, w)
+
+
+class _ListModel(nn.Module):
+    """Returns a list of tensors (unsupported raw output)."""
+    def forward(self, x):
+        return [_random_output(), _random_output()]
+
+
+# ─── Tests ───────────────────────────────────────────────────────────────────
+
+class TestModelOutputAdapterPassthrough:
+    def test_plain_tensor_passthrough(self):
+        adapter = ModelOutputAdapter(model=_TensorModel(), output_size=None)
+        out = adapter(_random_input())
+        assert isinstance(out, torch.Tensor)
+        assert out.shape == (B, C, H, W)
+
+    def test_plain_tensor_is_not_copied(self):
+        """When output is already correct, the same storage should be returned."""
+        inner_out = _random_output()
+        class _FixedModel(nn.Module):
+            def forward(self, x):
+                return inner_out
+        adapter = ModelOutputAdapter(model=_FixedModel(), output_size=None)
+        out = adapter(_random_input())
+        assert out.data_ptr() == inner_out.data_ptr()
+
+
+class TestModelOutputAdapterDictOutputs:
+    def test_dict_logits_key(self):
+        adapter = ModelOutputAdapter(model=_DictOutModel("logits"), output_size=None)
+        out = adapter(_random_input())
+        assert isinstance(out, torch.Tensor)
+        assert out.shape[-2:] == (H, W)
+
+    def test_dict_out_key(self):
+        adapter = ModelOutputAdapter(model=_DictOutModel("out"), output_size=None)
+        out = adapter(_random_input())
+        assert isinstance(out, torch.Tensor)
+
+    def test_dict_pred_key(self):
+        adapter = ModelOutputAdapter(model=_DictOutModel("pred"), output_size=None)
+        out = adapter(_random_input())
+        assert isinstance(out, torch.Tensor)
+
+    def test_dict_explicit_output_key(self):
+        adapter = ModelOutputAdapter(
+            model=_DictOutModel("custom_key"),
+            output_key="custom_key",
+            output_size=None,
+        )
+        out = adapter(_random_input())
+        assert isinstance(out, torch.Tensor)
+
+    def test_dict_wrong_explicit_key_raises(self):
+        adapter = ModelOutputAdapter(
+            model=_DictOutModel("logits"),
+            output_key="missing_key",
+            output_size=None,
+        )
+        with pytest.raises(KeyError, match="missing_key"):
+            adapter(_random_input())
+
+    def test_dict_no_known_key_raises(self):
+        class _WeirdDictModel(nn.Module):
+            def forward(self, x):
+                return {"unknown_key": _random_output()}
+        adapter = ModelOutputAdapter(model=_WeirdDictModel(), output_size=None)
+        with pytest.raises(KeyError):
+            adapter(_random_input())
+
+
+class TestModelOutputAdapterDataclassOutput:
+    def test_dataclass_logits_attribute(self):
+        adapter = ModelOutputAdapter(model=_DataclassModel(), output_size=None)
+        out = adapter(_random_input())
+        assert isinstance(out, torch.Tensor)
+        assert out.shape[-2:] == (H, W)
+
+
+class TestModelOutputAdapterTupleOutput:
+    def test_tuple_first_element(self):
+        adapter = ModelOutputAdapter(model=_TupleModel(), output_size=None)
+        out = adapter(_random_input())
+        assert isinstance(out, torch.Tensor)
+        assert out.shape[-2:] == (H, W)
+
+
+class TestModelOutputAdapterUpsampling:
+    def test_upsample_to_explicit_size(self):
+        target = (128, 128)
+        adapter = ModelOutputAdapter(model=_LowResModel(), output_size=target)
+        out = adapter(_random_input())
+        assert out.shape[-2:] == target
+
+    def test_upsample_to_input_size(self):
+        x = torch.randn(B, 3, H, W)
+        adapter = ModelOutputAdapter(model=_LowResModel(), output_size="input")
+        out = adapter(x)
+        assert out.shape[-2:] == (H, W)
+
+    def test_no_upsample_when_sizes_match(self):
+        """When output size already matches, interpolation should be skipped."""
+        adapter = ModelOutputAdapter(model=_TensorModel(), output_size="input")
+        x = torch.randn(B, 3, H, W)
+        out = adapter(x)
+        assert out.shape[-2:] == (H, W)
+
+
+class TestModelOutputAdapterErrors:
+    def test_list_model_output_raises_type_error(self):
+        adapter = ModelOutputAdapter(model=_ListModel(), output_size=None)
+        # List of tensors is supported via the list branch – first element returned
+        out = adapter(_random_input())
+        assert isinstance(out, torch.Tensor)
+
+    def test_unsupported_output_type_raises(self):
+        class _BadModel(nn.Module):
+            def forward(self, x):
+                return 42  # int – unsupported
+        adapter = ModelOutputAdapter(model=_BadModel(), output_size=None)
+        with pytest.raises(TypeError, match="unsupported output type"):
+            adapter(_random_input())


### PR DESCRIPTION
Phase 1 – ModelOutputAdapter (custom_models/transformer_adapters.py)
  Normalises any model output (HF dataclass, dict, tuple, plain tensor) to a
  (B,C,H,W) tensor with optional bilinear upsampling; unblocks all downstream
  transformer integration.

Phase 2 – HuggingFaceSegmentationWrapper (custom_models/huggingface_models.py)
  Loads any AutoModelForSemanticSegmentation from the Hub or a local path,
  bypasses the HF processor, and upsamples logits back to input resolution.

Phase 3 – TimmEncoderWithSMPDecoder (custom_models/timm_models.py)
  Combines a timm features_only backbone with SMP UNet/FPN/PAN decoders.
  Documents the zero-code SMP "tu-" prefix path as the recommended approach.

Phase 4 – TerraTorchSegmentationWrapper (custom_models/terratorch_models.py)
  Bridges TerraTorch foundation model encoders (Prithvi, Clay, SatMAE) with
  a linear or FPN segmentation head; handles single/multi-temporal inputs.

Phase 5 – LoRA / PEFT fine-tuning (fine_tuning/, config_definitions/)
  apply_fine_tuning_strategy() supports full / freeze_backbone / linear_probe
  / lora strategies; LoraAdapterConfig + FineTuningConfig dataclasses added;
  merge_lora_weights() for deployment.

Phase 6 – Hardened training loop (model_loader/model.py)
  _unpack_batch() replaces fragile batch.values() unpacking with configurable
  image_key/mask_key; set_encoder_trainable() made generic (no longer assumes
  .encoder attribute); _prepare_preds_for_metrics() guards metric calls.

Phase 7 – Inference pipeline (predict.py)
  Auto-merges LoRA adapter weights before inference; keep_lora_adapters flag
  allows skipping the merge for fine-tuning resumption.

Phase 8 – Example YAML configs (conf/examples/)
  smp_mit_b2.yaml, smp_tu_convnext.yaml, segformer_hf.yaml,
  segformer_lora.yaml, prithvi_terratorch.yaml, vit_linear_probe.yaml

Phase 9 – Unit tests (tests/)
  test_transformer_adapters, test_huggingface_models, test_timm_models,
  test_fine_tuning, test_model_training_step, test_terratorch_models,
  test_inference_pipeline – all offline, CPU-only, no weight downloads.

https://claude.ai/code/session_01T9RPrDKTBFPFsnxebyhnrn