### PR TITLE
Add ExperimentsRunner for successive training runs with different seeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,16 @@
 
 - Added `ExperimentsRunner` class (`tools/experiments_runner/experiments_runner.py`) that runs successive training experiments in series, each with an isolated seed and output directory.
 - Seeds can be specified explicitly (`seeds: [42, 101, 28]`) or generated automatically at runtime by supplying only `n_runs: 5`. Providing both values is accepted when they are consistent; a conflict raises a `ValueError` with a clear message.
-- Each run receives its seed via the existing `set_training_seed()` mechanism (Python `random`, NumPy, PyTorch CPU/CUDA, DataLoader workers), and writes checkpoints and logs to `<output_base_dir>/run_<idx:02d>/`.
+- Each run receives its seed via the existing `set_training_seed()` mechanism (Python `random`, NumPy, PyTorch CPU/CUDA, DataLoader workers), and writes checkpoints and logs to `<output_base_dir>/run_<idx:02d>_seed<seed>/` — the seed is visible directly in the filesystem path.
 - Wall-clock training time and all Lightning `callback_metrics` (`train/*`, `val/*`, `test/*`) are captured per run, including test metrics when a `test_dataset` block is present.
-- When `save_summary: true` (default), a `summary.csv` is written to `output_base_dir` containing per-run rows plus aggregated `mean` and `std` rows for all metrics and the training duration.
-- Added `ExperimentsRunnerConfig` dataclass in `config_definitions/experiments_runner_config.py`, registered in Hydra's ConfigStore.
+- When `save_summary: true` (default), a `summary.csv` is updated incrementally after each run with per-run rows plus aggregated `mean` and `std` rows for all metrics and the training duration.
+- After every completed run a `runner_state.json` is written to `output_base_dir`. Set `resume: true` in the config to skip already-completed runs on restart; auto-generated seeds are loaded from the state file so they remain stable across restarts.
+- If a `logger:` block is present in the training config, the runner stamps the run identity into it: `version` is set to `"run_<idx:02d>_seed<seed>"` for TensorBoard/CSV loggers; `name` is appended with the same tag for WandB-style loggers.
+- Added `ExperimentsRunnerConfig` dataclass in `config_definitions/experiments_runner_config.py` with new `resume` field, registered in Hydra's ConfigStore.
 - Added new dispatch mode `run-experiments` in `main.py`.
 - Added example configuration `conf/examples/experiments_runner.yaml` (UNet / ResNet-34, 3 fixed seeds).
 - Added user documentation `website/docs/user-guide/experiments_runner.md`.
-- Added 38 unit tests in `tests/test_experiments_runner.py` covering validation, seed resolution, config mutation, metric collection, CSV output, and the full `run()` integration with a mocked trainer.
+- Added 51 unit tests in `tests/test_experiments_runner.py` covering validation, seed resolution, config mutation, logger injection, metric collection, state file persistence, resume logic, and the full `run()` integration with a mocked trainer.
 
 ## Dataset Distillation
 - Added `dataset_distillation.py` utilities for dataset distillation using Coreset of Medoids (Optimal Quantization).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Unreleased
 
+## Experiments Runner
+
+- Added `ExperimentsRunner` class (`tools/experiments_runner/experiments_runner.py`) that runs successive training experiments in series, each with an isolated seed and output directory.
+- Seeds can be specified explicitly (`seeds: [42, 101, 28]`) or generated automatically at runtime by supplying only `n_runs: 5`. Providing both values is accepted when they are consistent; a conflict raises a `ValueError` with a clear message.
+- Each run receives its seed via the existing `set_training_seed()` mechanism (Python `random`, NumPy, PyTorch CPU/CUDA, DataLoader workers), and writes checkpoints and logs to `<output_base_dir>/run_<idx:02d>/`.
+- Wall-clock training time and all Lightning `callback_metrics` (`train/*`, `val/*`, `test/*`) are captured per run, including test metrics when a `test_dataset` block is present.
+- When `save_summary: true` (default), a `summary.csv` is written to `output_base_dir` containing per-run rows plus aggregated `mean` and `std` rows for all metrics and the training duration.
+- Added `ExperimentsRunnerConfig` dataclass in `config_definitions/experiments_runner_config.py`, registered in Hydra's ConfigStore.
+- Added new dispatch mode `run-experiments` in `main.py`.
+- Added example configuration `conf/examples/experiments_runner.yaml` (UNet / ResNet-34, 3 fixed seeds).
+- Added user documentation `website/docs/user-guide/experiments_runner.md`.
+- Added 38 unit tests in `tests/test_experiments_runner.py` covering validation, seed resolution, config mutation, metric collection, CSV output, and the full `run()` integration with a mocked trainer.
+
 ## Dataset Distillation
 - Added `dataset_distillation.py` utilities for dataset distillation using Coreset of Medoids (Optimal Quantization).
 - Implemented `extract_all_latents` for high-throughput embedding extraction from trained Autoencoders.

--- a/pytorch_segmentation_models_trainer/conf/examples/experiments_runner.yaml
+++ b/pytorch_segmentation_models_trainer/conf/examples/experiments_runner.yaml
@@ -1,0 +1,153 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Example: Experiments Runner — successive training runs with different seeds
+# ──────────────────────────────────────────────────────────────────────────────
+#
+# Use this config to run the same experiment multiple times with different
+# random seeds.  The framework trains in series, saves per-run checkpoints to
+# isolated directories, and writes a summary.csv with mean ± std metrics.
+#
+# How seeds work
+# ──────────────
+#   Option A — explicit seeds (recommended for reproducibility studies):
+#     experiments_runner:
+#       seeds: [42, 101, 28]      # 3 runs, seeds fixed
+#
+#   Option B — random seeds, fixed count:
+#     experiments_runner:
+#       n_runs: 5                 # 5 runs, seeds generated at runtime
+#
+#   Option C — consistent explicit spec (both must agree):
+#     experiments_runner:
+#       seeds: [42, 101, 28]
+#       n_runs: 3                 # must equal len(seeds)
+#
+# Output layout
+# ─────────────
+#   outputs/experiments_runner/
+#   ├── run_00/          ← pl_trainer checkpoints & logs for seed 42
+#   ├── run_01/          ← pl_trainer checkpoints & logs for seed 101
+#   ├── run_02/          ← pl_trainer checkpoints & logs for seed 28
+#   └── summary.csv      ← per-run metrics + mean ± std
+#
+# summary.csv columns
+# ───────────────────
+#   run | seed | duration_s | train/loss | val/loss | val/F1Score | ...
+#   0   | 42   | 142.30     | 0.210000   | 0.340000 | 0.820000   | ...
+#   1   | 101  | 139.80     | 0.190000   | 0.330000 | 0.825000   | ...
+#   2   | 28   | 141.10     | 0.200000   | 0.350000 | 0.818000   | ...
+#  mean | -    | 141.07     | 0.200000   | 0.340000 | 0.821000   | ...
+#  std  | -    | 1.26       | 0.010000   | 0.010000 | 0.003606   | ...
+# ──────────────────────────────────────────────────────────────────────────────
+
+defaults:
+  - _self_
+
+# ── Experiments Runner ────────────────────────────────────────────────────────
+mode: run-experiments
+
+experiments_runner:
+  seeds: [42, 101, 28]
+  output_base_dir: outputs/experiments_runner
+  save_summary: true
+  summary_metrics:
+    - val/loss
+    - val/F1Score
+
+# ── Backbone ─────────────────────────────────────────────────────────────────
+backbone:
+  name: resnet34
+  input_width: 256
+  input_height: 256
+
+# ── Hyperparameters ──────────────────────────────────────────────────────────
+hyperparameters:
+  model_name: unet_resnet34
+  backbone: resnet34
+  batch_size: 8
+  epochs: 50
+  max_lr: 1e-3
+  classes: 1
+
+# ── Model ─────────────────────────────────────────────────────────────────────
+model:
+  _target_: segmentation_models_pytorch.Unet
+  encoder_name: resnet34
+  encoder_weights: imagenet
+  in_channels: 3
+  classes: ${hyperparameters.classes}
+
+# ── Loss ─────────────────────────────────────────────────────────────────────
+loss:
+  _target_: segmentation_models_pytorch.losses.DiceLoss
+  mode: binary
+
+# ── Optimizer ────────────────────────────────────────────────────────────────
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: ${hyperparameters.max_lr}
+  weight_decay: 1e-4
+
+# ── Scheduler ────────────────────────────────────────────────────────────────
+scheduler_list:
+  - scheduler:
+      _target_: torch.optim.lr_scheduler.CosineAnnealingLR
+      T_max: ${hyperparameters.epochs}
+      eta_min: 1e-7
+    interval: epoch
+    frequency: 1
+
+# ── PyTorch Lightning Trainer ─────────────────────────────────────────────────
+pl_trainer:
+  max_epochs: ${hyperparameters.epochs}
+  accelerator: auto
+  devices: 1
+  precision: "16-mixed"
+  # default_root_dir is overridden per run by ExperimentsRunner
+
+# ── Datasets ─────────────────────────────────────────────────────────────────
+train_dataset:
+  _target_: pytorch_segmentation_models_trainer.dataset_loader.dataset.SegmentationDataset
+  input_csv_path: /data/train.csv
+  root_dir: /data
+  augmentation_list:
+    - _target_: albumentations.Resize
+      height: ${backbone.input_height}
+      width: ${backbone.input_width}
+    - _target_: albumentations.HorizontalFlip
+      p: 0.5
+    - _target_: albumentations.Normalize
+      mean: [0.485, 0.456, 0.406]
+      std: [0.229, 0.224, 0.225]
+    - _target_: albumentations.pytorch.ToTensorV2
+  data_loader:
+    batch_size: ${hyperparameters.batch_size}
+    num_workers: 8
+    shuffle: true
+    pin_memory: true
+    drop_last: true
+
+val_dataset:
+  _target_: pytorch_segmentation_models_trainer.dataset_loader.dataset.SegmentationDataset
+  input_csv_path: /data/val.csv
+  root_dir: /data
+  augmentation_list:
+    - _target_: albumentations.Resize
+      height: ${backbone.input_height}
+      width: ${backbone.input_width}
+    - _target_: albumentations.Normalize
+      mean: [0.485, 0.456, 0.406]
+      std: [0.229, 0.224, 0.225]
+    - _target_: albumentations.pytorch.ToTensorV2
+  data_loader:
+    batch_size: ${hyperparameters.batch_size}
+    num_workers: 8
+    shuffle: false
+    pin_memory: true
+    drop_last: false
+
+# ── Metrics ───────────────────────────────────────────────────────────────────
+metrics:
+  - _target_: torchmetrics.JaccardIndex
+    task: binary
+  - _target_: torchmetrics.F1Score
+    task: binary

--- a/pytorch_segmentation_models_trainer/conf/examples/experiments_runner.yaml
+++ b/pytorch_segmentation_models_trainer/conf/examples/experiments_runner.yaml
@@ -24,10 +24,11 @@
 # Output layout
 # ─────────────
 #   outputs/experiments_runner/
-#   ├── run_00/          ← pl_trainer checkpoints & logs for seed 42
-#   ├── run_01/          ← pl_trainer checkpoints & logs for seed 101
-#   ├── run_02/          ← pl_trainer checkpoints & logs for seed 28
-#   └── summary.csv      ← per-run metrics + mean ± std
+#   ├── run_00_seed42/   ← pl_trainer checkpoints & logs (seed visible in path)
+#   ├── run_01_seed101/
+#   ├── run_02_seed28/
+#   ├── runner_state.json ← written after each run; enables resume
+#   └── summary.csv       ← updated after each run; per-run metrics + mean ± std
 #
 # summary.csv columns
 # ───────────────────
@@ -49,6 +50,7 @@ experiments_runner:
   seeds: [42, 101, 28]
   output_base_dir: outputs/experiments_runner
   save_summary: true
+  resume: false          # set to true to skip already-completed runs on restart
   summary_metrics:
     - val/loss
     - val/F1Score

--- a/pytorch_segmentation_models_trainer/config_definitions/experiments_runner_config.py
+++ b/pytorch_segmentation_models_trainer/config_definitions/experiments_runner_config.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+ pytorch_segmentation_models_trainer
+                              -------------------
+        begin                : 2026-05-07
+        copyright            : (C) 2026 by Philipe Borba
+        email                : philipeborba at gmail dot com
+ ***************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from hydra.core.config_store import ConfigStore
+
+
+@dataclass
+class ExperimentsRunnerConfig:
+    """Configuration for running successive training experiments with different seeds.
+
+    Exactly one of ``seeds`` or ``n_runs`` must be supplied (or both, provided
+    ``n_runs == len(seeds)``).  If only ``n_runs`` is given the seeds are
+    generated randomly at runtime using :mod:`secrets`.
+
+    Args:
+        n_runs: Number of successive runs. Required when ``seeds`` is absent.
+            Ignored (or validated for consistency) when ``seeds`` is present.
+        seeds: Explicit seed list — one entry per run.  Determines the number
+            of runs.  When absent, ``n_runs`` random seeds are generated.
+        output_base_dir: Root directory for per-run outputs.  Each run writes
+            to ``<output_base_dir>/run_<idx:02d>/``.
+        save_summary: When ``True`` (default) a ``summary.csv`` with per-run
+            metrics and mean ± std aggregation is written to
+            ``output_base_dir`` after all runs finish.
+        summary_metrics: Metric keys (as logged by Lightning, e.g.
+            ``"val/loss"``) to highlight in log output.  All available
+            metrics are always written to the CSV regardless of this list.
+
+    Example YAML:
+
+    .. code-block:: yaml
+
+        experiments_runner:
+          seeds: [42, 101, 28]
+          output_base_dir: outputs/reproducibility_study
+          save_summary: true
+          summary_metrics:
+            - val/loss
+            - val/F1Score
+    """
+
+    n_runs: Optional[int] = None
+    seeds: Optional[List[int]] = None
+    output_base_dir: str = "outputs/experiments_runner"
+    save_summary: bool = True
+    summary_metrics: List[str] = field(default_factory=lambda: ["val/loss"])
+
+
+def _register_configs() -> None:
+    cs = ConfigStore.instance()
+    cs.store(
+        name="experiments_runner_config",
+        node=ExperimentsRunnerConfig,
+        group="experiments_runner",
+    )
+
+
+_register_configs()

--- a/pytorch_segmentation_models_trainer/config_definitions/experiments_runner_config.py
+++ b/pytorch_segmentation_models_trainer/config_definitions/experiments_runner_config.py
@@ -37,13 +37,18 @@ class ExperimentsRunnerConfig:
         seeds: Explicit seed list — one entry per run.  Determines the number
             of runs.  When absent, ``n_runs`` random seeds are generated.
         output_base_dir: Root directory for per-run outputs.  Each run writes
-            to ``<output_base_dir>/run_<idx:02d>/``.
+            to ``<output_base_dir>/run_<idx:02d>_seed<seed>/``.
         save_summary: When ``True`` (default) a ``summary.csv`` with per-run
-            metrics and mean ± std aggregation is written to
-            ``output_base_dir`` after all runs finish.
+            metrics and mean ± std aggregation is written incrementally to
+            ``output_base_dir`` after each run finishes.
         summary_metrics: Metric keys (as logged by Lightning, e.g.
             ``"val/loss"``) to highlight in log output.  All available
             metrics are always written to the CSV regardless of this list.
+        resume: When ``True`` and a ``runner_state.json`` exists in
+            ``output_base_dir``, already-completed runs are skipped and
+            execution continues from the first pending run.  Seeds are
+            loaded from the state file so auto-generated seeds are stable
+            across restarts.
 
     Example YAML:
 
@@ -53,6 +58,7 @@ class ExperimentsRunnerConfig:
           seeds: [42, 101, 28]
           output_base_dir: outputs/reproducibility_study
           save_summary: true
+          resume: false
           summary_metrics:
             - val/loss
             - val/F1Score
@@ -63,6 +69,7 @@ class ExperimentsRunnerConfig:
     output_base_dir: str = "outputs/experiments_runner"
     save_summary: bool = True
     summary_metrics: List[str] = field(default_factory=lambda: ["val/loss"])
+    resume: bool = False
 
 
 def _register_configs() -> None:

--- a/pytorch_segmentation_models_trainer/main.py
+++ b/pytorch_segmentation_models_trainer/main.py
@@ -77,6 +77,11 @@ def main(cfg: DictConfig):
     elif cfg.mode == "evaluate-experiments":
         from pytorch_segmentation_models_trainer.evaluate_experiments import evaluate
         return evaluate(cfg)
+    elif cfg.mode == "run-experiments":
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import (
+            ExperimentsRunner,
+        )
+        return ExperimentsRunner(cfg).run()
     else:
         raise NotImplementedError
 

--- a/pytorch_segmentation_models_trainer/tools/experiments_runner/experiments_runner.py
+++ b/pytorch_segmentation_models_trainer/tools/experiments_runner/experiments_runner.py
@@ -17,19 +17,23 @@
  ***************************************************************************/
 """
 import csv
+import dataclasses
+import json
 import logging
 import os
 import secrets
 import statistics
 import time
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from omegaconf import DictConfig, OmegaConf
 
 from pytorch_segmentation_models_trainer.train import train
 
 logger = logging.getLogger(__name__)
+
+_STATE_FILE = "runner_state.json"
 
 
 @dataclass
@@ -47,7 +51,7 @@ class RunResult:
         test_metrics: Final test metrics, keyed with the ``test/`` prefix.
             Empty when no test dataset is configured.
         output_dir: Absolute path to the per-run output directory
-            (``<output_base_dir>/run_<run_idx:02d>``).
+            (``<output_base_dir>/run_<run_idx:02d>_seed<seed>``).
     """
 
     run_idx: int
@@ -64,8 +68,14 @@ class ExperimentsRunner:
 
     The runner takes a full Hydra ``DictConfig`` that contains both the usual
     training configuration and an ``experiments_runner`` block.  For each run
-    it strips that block, overrides the seed and the Lightning
-    ``default_root_dir``, and delegates to :func:`train`.
+    it strips that block, overrides the seed, adjusts the Lightning
+    ``default_root_dir``, and injects run identity into the logger before
+    delegating to :func:`train`.
+
+    After every completed run the runner writes a ``runner_state.json`` to
+    ``output_base_dir`` and, when ``save_summary`` is enabled, updates
+    ``summary.csv``.  Set ``resume: true`` to skip already-completed runs
+    on restart.
 
     Args:
         cfg: Full Hydra config including the ``experiments_runner`` sub-tree.
@@ -130,8 +140,9 @@ class ExperimentsRunner:
     def _build_run_cfg(self, run_idx: int, seed: int) -> Tuple[DictConfig, str]:
         """Build a training config for a single run.
 
-        Removes the ``experiments_runner`` block, sets the seed, and adjusts
-        ``pl_trainer.default_root_dir`` to an isolated per-run directory.
+        Removes the ``experiments_runner`` block, sets the seed, adjusts
+        ``pl_trainer.default_root_dir`` to an isolated per-run directory, and
+        injects the run identity into the configured logger (if any).
 
         Args:
             run_idx: Zero-based run index.
@@ -148,14 +159,49 @@ class ExperimentsRunner:
         OmegaConf.update(run_cfg, "seed", seed, merge=True)
 
         output_dir = os.path.join(
-            self.runner_cfg.output_base_dir, f"run_{run_idx:02d}"
+            self.runner_cfg.output_base_dir, f"run_{run_idx:02d}_seed{seed}"
         )
         if "pl_trainer" in run_cfg:
             OmegaConf.update(
                 run_cfg, "pl_trainer.default_root_dir", output_dir, merge=True
             )
 
+        self._inject_run_identity_into_logger(run_cfg, run_idx, seed)
+
         return run_cfg, output_dir
+
+    def _inject_run_identity_into_logger(
+        self, run_cfg: DictConfig, run_idx: int, seed: int
+    ) -> None:
+        """Stamp run_idx and seed into the logger config.
+
+        * If the logger has a ``version`` field (TensorBoardLogger, CSVLogger):
+          set it to ``"run_<idx:02d>_seed<seed>"``.
+        * If the logger has a ``name`` field but no ``version`` (WandbLogger):
+          append ``_run_<idx:02d>_seed<seed>`` to the name.
+        * If no ``logger`` key or logger is a plain bool (Lightning default):
+          do nothing.
+
+        Args:
+            run_cfg: Per-run config (already stripped of experiments_runner).
+            run_idx: Zero-based run index.
+            seed: Seed for this run.
+        """
+        if "logger" not in run_cfg:
+            return
+        logger_cfg = run_cfg.logger
+        # Plain bool → Lightning default logger, nothing to modify.
+        if not isinstance(logger_cfg, DictConfig):
+            return
+
+        run_tag = f"run_{run_idx:02d}_seed{seed}"
+        if "version" in logger_cfg:
+            OmegaConf.update(run_cfg, "logger.version", run_tag, merge=True)
+        elif "name" in logger_cfg:
+            current_name = OmegaConf.select(run_cfg, "logger.name")
+            OmegaConf.update(
+                run_cfg, "logger.name", f"{current_name}_{run_tag}", merge=True
+            )
 
     def _collect_metrics(
         self, trainer
@@ -173,6 +219,33 @@ class ExperimentsRunner:
         val_metrics = {k: v for k, v in all_metrics.items() if k.startswith("val/")}
         test_metrics = {k: v for k, v in all_metrics.items() if k.startswith("test/")}
         return train_metrics, val_metrics, test_metrics
+
+    # ------------------------------------------------------------------
+    # State persistence
+    # ------------------------------------------------------------------
+
+    def _state_path(self) -> str:
+        return os.path.join(self.runner_cfg.output_base_dir, _STATE_FILE)
+
+    def _save_state(self, all_seeds: List[int], results: List[RunResult]) -> None:
+        """Persist seed list and completed runs to ``runner_state.json``.
+
+        Args:
+            all_seeds: Full ordered seed list for the experiment sequence.
+            results: Completed :class:`RunResult` objects so far.
+        """
+        os.makedirs(self.runner_cfg.output_base_dir, exist_ok=True)
+        state = {
+            "all_seeds": all_seeds,
+            "completed_runs": [dataclasses.asdict(r) for r in results],
+        }
+        with open(self._state_path(), "w") as f:
+            json.dump(state, f, indent=2)
+
+    def _load_state(self) -> dict:
+        """Load state from ``runner_state.json``."""
+        with open(self._state_path()) as f:
+            return json.load(f)
 
     # ------------------------------------------------------------------
     # Core execution
@@ -222,22 +295,54 @@ class ExperimentsRunner:
         )
 
     def run(self) -> List[RunResult]:
-        """Run all experiments in series.
+        """Run all experiments in series, with optional resume support.
+
+        On each completed run the state is persisted to ``runner_state.json``
+        and ``summary.csv`` is updated (when ``save_summary`` is enabled).
+        When ``resume: true`` is set and a state file exists, already-completed
+        runs are skipped; seeds are loaded from the state file so
+        auto-generated seeds remain stable across restarts.
 
         Returns:
-            List of :class:`RunResult`, one per run, in execution order.
+            List of :class:`RunResult`, one per run, ordered by ``run_idx``.
         """
-        seeds = self._resolve_seeds()
-        results: List[RunResult] = []
+        resume = self.runner_cfg.get("resume", False)
+        state_exists = os.path.exists(self._state_path())
 
-        for run_idx, seed in enumerate(seeds):
+        if resume and state_exists:
+            state = self._load_state()
+            all_seeds = state["all_seeds"]
+            completed_results = [RunResult(**r) for r in state["completed_runs"]]
+            logger.info(
+                "ExperimentsRunner — resuming: %d/%d runs already complete.",
+                len(completed_results),
+                len(all_seeds),
+            )
+        else:
+            all_seeds = self._resolve_seeds()
+            completed_results = []
+
+        completed_indices = {r.run_idx for r in completed_results}
+        results: List[RunResult] = list(completed_results)
+
+        for run_idx, seed in enumerate(all_seeds):
+            if run_idx in completed_indices:
+                logger.info(
+                    "ExperimentsRunner — run %d (seed=%d) already done, skipping.",
+                    run_idx,
+                    seed,
+                )
+                continue
+
             result = self._run_single(run_idx, seed)
             results.append(result)
+            results_sorted = sorted(results, key=lambda r: r.run_idx)
 
-        if self.runner_cfg.get("save_summary", True):
-            self._save_summary(results)
+            self._save_state(all_seeds, results_sorted)
+            if self.runner_cfg.get("save_summary", True):
+                self._save_summary(results_sorted)
 
-        return results
+        return sorted(results, key=lambda r: r.run_idx)
 
     # ------------------------------------------------------------------
     # Summary CSV
@@ -285,7 +390,9 @@ class ExperimentsRunner:
         std_row: Dict = {
             "run": "std",
             "seed": "-",
-            "duration_s": _fmt(statistics.stdev(durations)) if len(durations) >= 2 else "0.000000",
+            "duration_s": (
+                _fmt(statistics.stdev(durations)) if len(durations) >= 2 else "0.000000"
+            ),
         }
 
         for k in all_metric_keys:

--- a/pytorch_segmentation_models_trainer/tools/experiments_runner/experiments_runner.py
+++ b/pytorch_segmentation_models_trainer/tools/experiments_runner/experiments_runner.py
@@ -1,0 +1,305 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+ pytorch_segmentation_models_trainer
+                              -------------------
+        begin                : 2026-05-07
+        copyright            : (C) 2026 by Philipe Borba
+        email                : philipeborba at gmail dot com
+ ***************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+import csv
+import logging
+import os
+import secrets
+import statistics
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+
+from omegaconf import DictConfig, OmegaConf
+
+from pytorch_segmentation_models_trainer.train import train
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RunResult:
+    """Result produced by a single training run.
+
+    Args:
+        run_idx: Zero-based index of this run within the experiment sequence.
+        seed: Random seed used for this run.
+        training_time_seconds: Wall-clock seconds from ``trainer.fit`` start to
+            end (includes ``trainer.test`` when a test dataset is configured).
+        train_metrics: Final training metrics from
+            ``trainer.callback_metrics``, keyed with the ``train/`` prefix.
+        val_metrics: Final validation metrics, keyed with the ``val/`` prefix.
+        test_metrics: Final test metrics, keyed with the ``test/`` prefix.
+            Empty when no test dataset is configured.
+        output_dir: Absolute path to the per-run output directory
+            (``<output_base_dir>/run_<run_idx:02d>``).
+    """
+
+    run_idx: int
+    seed: int
+    training_time_seconds: float
+    train_metrics: Dict[str, float]
+    val_metrics: Dict[str, float]
+    test_metrics: Dict[str, float]
+    output_dir: str
+
+
+class ExperimentsRunner:
+    """Runs successive training experiments in series with different seeds.
+
+    The runner takes a full Hydra ``DictConfig`` that contains both the usual
+    training configuration and an ``experiments_runner`` block.  For each run
+    it strips that block, overrides the seed and the Lightning
+    ``default_root_dir``, and delegates to :func:`train`.
+
+    Args:
+        cfg: Full Hydra config including the ``experiments_runner`` sub-tree.
+
+    Raises:
+        ValueError: If neither ``seeds`` nor ``n_runs`` is provided, or if
+            both are provided with inconsistent values.
+
+    Example::
+
+        runner = ExperimentsRunner(cfg)
+        results = runner.run()
+        for r in results:
+            print(r.seed, r.val_metrics)
+    """
+
+    def __init__(self, cfg: DictConfig) -> None:
+        self.cfg = cfg
+        self.runner_cfg = cfg.experiments_runner
+        self._validate()
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    def _validate(self) -> None:
+        seeds = self.runner_cfg.get("seeds", None)
+        n_runs = self.runner_cfg.get("n_runs", None)
+
+        if seeds is None and n_runs is None:
+            raise ValueError(
+                "experiments_runner: either 'seeds' or 'n_runs' must be provided."
+            )
+        if seeds is not None and n_runs is not None and n_runs != len(seeds):
+            raise ValueError(
+                f"experiments_runner.n_runs ({n_runs}) must equal "
+                f"len(experiments_runner.seeds) ({len(seeds)}) when both are provided."
+            )
+
+    # ------------------------------------------------------------------
+    # Public helpers (also used in tests)
+    # ------------------------------------------------------------------
+
+    def _n_runs(self) -> int:
+        """Return the resolved number of runs."""
+        seeds = self.runner_cfg.get("seeds", None)
+        if seeds is not None:
+            return len(seeds)
+        return int(self.runner_cfg.n_runs)
+
+    def _resolve_seeds(self) -> List[int]:
+        """Return the list of seeds for all runs.
+
+        Uses explicit seeds when provided; otherwise generates
+        ``n_runs`` cryptographically random 31-bit integers.
+        """
+        seeds = self.runner_cfg.get("seeds", None)
+        if seeds is not None:
+            return list(seeds)
+        return [secrets.randbelow(2**31) for _ in range(self._n_runs())]
+
+    def _build_run_cfg(self, run_idx: int, seed: int) -> Tuple[DictConfig, str]:
+        """Build a training config for a single run.
+
+        Removes the ``experiments_runner`` block, sets the seed, and adjusts
+        ``pl_trainer.default_root_dir`` to an isolated per-run directory.
+
+        Args:
+            run_idx: Zero-based run index.
+            seed: Seed to inject into the config.
+
+        Returns:
+            Tuple of (run_cfg, output_dir).
+        """
+        keys = [k for k in self.cfg if k != "experiments_runner"]
+        run_cfg = OmegaConf.masked_copy(self.cfg, keys)
+
+        # Allow writing to the (possibly struct-locked) config copy.
+        OmegaConf.set_struct(run_cfg, False)
+        OmegaConf.update(run_cfg, "seed", seed, merge=True)
+
+        output_dir = os.path.join(
+            self.runner_cfg.output_base_dir, f"run_{run_idx:02d}"
+        )
+        if "pl_trainer" in run_cfg:
+            OmegaConf.update(
+                run_cfg, "pl_trainer.default_root_dir", output_dir, merge=True
+            )
+
+        return run_cfg, output_dir
+
+    def _collect_metrics(
+        self, trainer
+    ) -> Tuple[Dict[str, float], Dict[str, float], Dict[str, float]]:
+        """Extract and split ``trainer.callback_metrics`` by prefix.
+
+        Args:
+            trainer: A fitted :class:`pytorch_lightning.Trainer` instance.
+
+        Returns:
+            Tuple of (train_metrics, val_metrics, test_metrics).
+        """
+        all_metrics = {k: float(v) for k, v in trainer.callback_metrics.items()}
+        train_metrics = {k: v for k, v in all_metrics.items() if k.startswith("train/")}
+        val_metrics = {k: v for k, v in all_metrics.items() if k.startswith("val/")}
+        test_metrics = {k: v for k, v in all_metrics.items() if k.startswith("test/")}
+        return train_metrics, val_metrics, test_metrics
+
+    # ------------------------------------------------------------------
+    # Core execution
+    # ------------------------------------------------------------------
+
+    def _run_single(self, run_idx: int, seed: int) -> RunResult:
+        """Execute one training run and return its result.
+
+        Args:
+            run_idx: Zero-based index of this run.
+            seed: Seed for this run.
+
+        Returns:
+            :class:`RunResult` with timing and metrics.
+        """
+        run_cfg, output_dir = self._build_run_cfg(run_idx, seed)
+
+        logger.info(
+            "ExperimentsRunner — starting run %d/%d | seed=%d | output=%s",
+            run_idx + 1,
+            self._n_runs(),
+            seed,
+            output_dir,
+        )
+
+        start = time.perf_counter()
+        trainer = train(run_cfg)
+        elapsed = time.perf_counter() - start
+
+        train_metrics, val_metrics, test_metrics = self._collect_metrics(trainer)
+
+        logger.info(
+            "ExperimentsRunner — run %d done in %.1fs | val: %s",
+            run_idx + 1,
+            elapsed,
+            val_metrics,
+        )
+
+        return RunResult(
+            run_idx=run_idx,
+            seed=seed,
+            training_time_seconds=elapsed,
+            train_metrics=train_metrics,
+            val_metrics=val_metrics,
+            test_metrics=test_metrics,
+            output_dir=output_dir,
+        )
+
+    def run(self) -> List[RunResult]:
+        """Run all experiments in series.
+
+        Returns:
+            List of :class:`RunResult`, one per run, in execution order.
+        """
+        seeds = self._resolve_seeds()
+        results: List[RunResult] = []
+
+        for run_idx, seed in enumerate(seeds):
+            result = self._run_single(run_idx, seed)
+            results.append(result)
+
+        if self.runner_cfg.get("save_summary", True):
+            self._save_summary(results)
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Summary CSV
+    # ------------------------------------------------------------------
+
+    def _save_summary(self, results: List[RunResult]) -> None:
+        """Write ``summary.csv`` with per-run metrics and mean ± std rows.
+
+        Args:
+            results: List of completed :class:`RunResult` objects.
+        """
+        output_base_dir = self.runner_cfg.output_base_dir
+        os.makedirs(output_base_dir, exist_ok=True)
+        summary_path = os.path.join(output_base_dir, "summary.csv")
+
+        all_metric_keys = sorted(
+            {k for r in results for k in {**r.train_metrics, **r.val_metrics, **r.test_metrics}}
+        )
+        fieldnames = ["run", "seed", "duration_s"] + all_metric_keys
+
+        def _all_metrics(r: RunResult) -> Dict[str, float]:
+            return {**r.train_metrics, **r.val_metrics, **r.test_metrics}
+
+        def _fmt(v) -> str:
+            return f"{v:.6f}"
+
+        rows = []
+        for r in results:
+            m = _all_metrics(r)
+            row: Dict = {
+                "run": r.run_idx,
+                "seed": r.seed,
+                "duration_s": f"{r.training_time_seconds:.2f}",
+            }
+            for k in all_metric_keys:
+                row[k] = _fmt(m[k]) if k in m else ""
+            rows.append(row)
+
+        durations = [r.training_time_seconds for r in results]
+        mean_row: Dict = {
+            "run": "mean",
+            "seed": "-",
+            "duration_s": _fmt(statistics.mean(durations)),
+        }
+        std_row: Dict = {
+            "run": "std",
+            "seed": "-",
+            "duration_s": _fmt(statistics.stdev(durations)) if len(durations) >= 2 else "0.000000",
+        }
+
+        for k in all_metric_keys:
+            vals = [_all_metrics(r)[k] for r in results if k in _all_metrics(r)]
+            mean_row[k] = _fmt(statistics.mean(vals)) if vals else ""
+            std_row[k] = (
+                _fmt(statistics.stdev(vals)) if len(vals) >= 2 else ("0.000000" if vals else "")
+            )
+
+        rows.extend([mean_row, std_row])
+
+        with open(summary_path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
+
+        logger.info("ExperimentsRunner — summary saved to %s", summary_path)

--- a/tests/test_experiments_runner.py
+++ b/tests/test_experiments_runner.py
@@ -5,6 +5,7 @@ Tests for ExperimentsRunner (TDD — written before implementation).
 Run with:
     uv run pytest tests/test_experiments_runner.py -v --tb=short
 """
+import json
 import os
 import shutil
 import tempfile
@@ -23,6 +24,7 @@ def _make_runner_cfg(
     output_base_dir=None,
     save_summary=False,
     summary_metrics=None,
+    resume=False,
     extra=None,
 ):
     """Build a minimal DictConfig that ExperimentsRunner accepts."""
@@ -33,6 +35,7 @@ def _make_runner_cfg(
         runner_block["n_runs"] = n_runs
     runner_block["save_summary"] = save_summary
     runner_block["summary_metrics"] = summary_metrics or ["val/loss"]
+    runner_block["resume"] = resume
     if extra:
         runner_block.update(extra)
 
@@ -167,11 +170,12 @@ class TestBuildRunCfg(BasicTestCase):
         run_cfg, _ = ExperimentsRunner(cfg)._build_run_cfg(0, 42)
         self.assertIn("mode", run_cfg)
 
-    def test_output_dir_ends_with_correct_run_folder(self):
+    def test_output_dir_contains_run_idx_and_seed(self):
         ExperimentsRunner = self._import()
         cfg = _make_runner_cfg(seeds=[42, 101], output_base_dir="/base/runs")
         _, output_dir = ExperimentsRunner(cfg)._build_run_cfg(1, 101)
-        self.assertTrue(output_dir.endswith("run_01"))
+        self.assertIn("run_01", output_dir)
+        self.assertIn("seed101", output_dir)
 
     def test_pl_trainer_default_root_dir_updated(self):
         ExperimentsRunner = self._import()
@@ -184,12 +188,65 @@ class TestBuildRunCfg(BasicTestCase):
         cfg = _make_runner_cfg(seeds=[42], output_base_dir="/base")
         _, output_dir = ExperimentsRunner(cfg)._build_run_cfg(0, 42)
         self.assertIn("run_00", output_dir)
+        self.assertIn("seed42", output_dir)
 
     def test_second_run_idx_formatted(self):
         ExperimentsRunner = self._import()
         cfg = _make_runner_cfg(seeds=[42, 99], output_base_dir="/base")
         _, output_dir = ExperimentsRunner(cfg)._build_run_cfg(9, 99)
         self.assertIn("run_09", output_dir)
+        self.assertIn("seed99", output_dir)
+
+
+class TestLoggerInjection(BasicTestCase):
+    """_build_run_cfg() must inject run identity into the configured logger."""
+
+    def _import(self):
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import (
+            ExperimentsRunner,
+        )
+        return ExperimentsRunner
+
+    def _make_cfg_with_logger(self, logger_block):
+        base = _make_runner_cfg(seeds=[42])
+        cfg_dict = OmegaConf.to_container(base, resolve=False)
+        cfg_dict["logger"] = logger_block
+        return OmegaConf.create(cfg_dict)
+
+    def test_version_field_set_to_run_tag(self):
+        ExperimentsRunner = self._import()
+        cfg = self._make_cfg_with_logger({
+            "_target_": "pytorch_lightning.loggers.TensorBoardLogger",
+            "save_dir": "logs",
+            "name": "my_exp",
+            "version": 0,
+        })
+        run_cfg, _ = ExperimentsRunner(cfg)._build_run_cfg(0, 42)
+        self.assertEqual(run_cfg.logger.version, "run_00_seed42")
+
+    def test_name_appended_when_no_version(self):
+        ExperimentsRunner = self._import()
+        cfg = self._make_cfg_with_logger({
+            "_target_": "pytorch_lightning.loggers.WandbLogger",
+            "name": "my_exp",
+            "project": "segmentation",
+        })
+        run_cfg, _ = ExperimentsRunner(cfg)._build_run_cfg(0, 42)
+        self.assertIn("run_00_seed42", run_cfg.logger.name)
+        self.assertTrue(run_cfg.logger.name.startswith("my_exp"))
+
+    def test_no_logger_in_cfg_no_crash(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(seeds=[42])
+        # Must not raise even without a logger block
+        run_cfg, _ = ExperimentsRunner(cfg)._build_run_cfg(0, 42)
+        self.assertNotIn("logger", run_cfg)
+
+    def test_lightning_default_logger_true_no_crash(self):
+        ExperimentsRunner = self._import()
+        cfg = self._make_cfg_with_logger(True)
+        run_cfg, _ = ExperimentsRunner(cfg)._build_run_cfg(0, 42)
+        self.assertEqual(run_cfg.logger, True)
 
 
 class TestCollectMetrics(BasicTestCase):
@@ -250,12 +307,13 @@ class TestRunMethod(BasicTestCase):
         super().setUp()
         self.tmp = self.make_temp_dir()
 
-    def _make_cfg(self, seeds=None, n_runs=None, save_summary=False, metrics=None):
+    def _make_cfg(self, seeds=None, n_runs=None, save_summary=False, resume=False):
         return _make_runner_cfg(
             seeds=seeds,
             n_runs=n_runs,
             output_base_dir=self.tmp,
             save_summary=save_summary,
+            resume=resume,
         )
 
     @patch(_TRAIN_PATH)
@@ -375,11 +433,12 @@ class TestRunMethod(BasicTestCase):
         self.assertIn("duration_s", header)
 
     @patch(_TRAIN_PATH)
-    def test_result_output_dir_matches_run_folder(self, mock_train):
+    def test_result_output_dir_contains_seed(self, mock_train):
         mock_train.return_value = _make_mock_trainer()
         from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
         results = ExperimentsRunner(self._make_cfg(seeds=[42])).run()
         self.assertIn("run_00", results[0].output_dir)
+        self.assertIn("seed42", results[0].output_dir)
 
     @patch(_TRAIN_PATH)
     def test_single_run_std_row_is_zero(self, mock_train):
@@ -391,3 +450,176 @@ class TestRunMethod(BasicTestCase):
         with open(os.path.join(self.tmp, "summary.csv")) as f:
             content = f.read()
         self.assertIn("std", content)
+
+    @patch(_TRAIN_PATH)
+    def test_summary_written_after_each_run(self, mock_train):
+        """summary.csv must exist after the first run, not just at the end."""
+        summaries_seen = []
+
+        def fake_train(cfg):
+            summaries_seen.append(
+                os.path.exists(os.path.join(self.tmp, "summary.csv"))
+            )
+            return _make_mock_trainer({"val/loss": 0.5})
+
+        mock_train.side_effect = fake_train
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        ExperimentsRunner(self._make_cfg(seeds=[42, 101], save_summary=True)).run()
+        # After run 0 completes, summary already exists when run 1 starts
+        self.assertTrue(summaries_seen[1], "summary.csv was not present before run 1 started")
+
+
+class TestStateFile(BasicTestCase):
+    """runner_state.json is written after each run and drives resume logic."""
+
+    def setUp(self):
+        super().setUp()
+        self.tmp = self.make_temp_dir()
+
+    def _make_cfg(self, seeds=None, n_runs=None, resume=False, save_summary=False):
+        return _make_runner_cfg(
+            seeds=seeds,
+            n_runs=n_runs,
+            output_base_dir=self.tmp,
+            save_summary=save_summary,
+            resume=resume,
+        )
+
+    @patch(_TRAIN_PATH)
+    def test_state_file_created_after_first_run(self, mock_train):
+        state_path = os.path.join(self.tmp, "runner_state.json")
+        state_snapshots = []
+
+        def fake_train(cfg):
+            state_snapshots.append(os.path.exists(state_path))
+            return _make_mock_trainer()
+
+        mock_train.side_effect = fake_train
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        ExperimentsRunner(self._make_cfg(seeds=[42, 101])).run()
+        # State file must exist before run 1 starts (written after run 0)
+        self.assertTrue(state_snapshots[1])
+
+    @patch(_TRAIN_PATH)
+    def test_state_file_contains_all_seeds(self, mock_train):
+        mock_train.return_value = _make_mock_trainer()
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        ExperimentsRunner(self._make_cfg(seeds=[42, 101, 28])).run()
+        with open(os.path.join(self.tmp, "runner_state.json")) as f:
+            state = json.load(f)
+        self.assertEqual(state["all_seeds"], [42, 101, 28])
+
+    @patch(_TRAIN_PATH)
+    def test_state_file_records_completed_runs(self, mock_train):
+        mock_train.return_value = _make_mock_trainer({"val/loss": 0.4})
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        ExperimentsRunner(self._make_cfg(seeds=[42, 101])).run()
+        with open(os.path.join(self.tmp, "runner_state.json")) as f:
+            state = json.load(f)
+        self.assertEqual(len(state["completed_runs"]), 2)
+        self.assertEqual(state["completed_runs"][0]["seed"], 42)
+        self.assertEqual(state["completed_runs"][1]["seed"], 101)
+
+    @patch(_TRAIN_PATH)
+    def test_state_file_preserves_auto_seeds_for_resume(self, mock_train):
+        """With n_runs, state file must store the generated seeds so resume uses them."""
+        mock_train.return_value = _make_mock_trainer()
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        ExperimentsRunner(self._make_cfg(n_runs=3)).run()
+        with open(os.path.join(self.tmp, "runner_state.json")) as f:
+            state = json.load(f)
+        self.assertEqual(len(state["all_seeds"]), 3)
+        self.assertEqual(len(state["completed_runs"]), 3)
+
+    @patch(_TRAIN_PATH)
+    def test_resume_skips_already_completed_runs(self, mock_train):
+        mock_train.return_value = _make_mock_trainer()
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import (
+            ExperimentsRunner, RunResult,
+        )
+        # Pre-write a state file with run 0 completed
+        completed = RunResult(
+            run_idx=0, seed=42, training_time_seconds=10.0,
+            train_metrics={"train/loss": 0.2},
+            val_metrics={"val/loss": 0.4},
+            test_metrics={},
+            output_dir=os.path.join(self.tmp, "run_00_seed42"),
+        )
+        import dataclasses
+        state = {"all_seeds": [42, 101, 28], "completed_runs": [dataclasses.asdict(completed)]}
+        os.makedirs(self.tmp, exist_ok=True)
+        with open(os.path.join(self.tmp, "runner_state.json"), "w") as f:
+            json.dump(state, f)
+
+        cfg = self._make_cfg(seeds=[42, 101, 28], resume=True)
+        results = ExperimentsRunner(cfg).run()
+
+        # train() must only have been called for runs 1 and 2
+        self.assertEqual(mock_train.call_count, 2)
+        self.assertEqual(len(results), 3)
+
+    @patch(_TRAIN_PATH)
+    def test_resume_false_ignores_existing_state(self, mock_train):
+        mock_train.return_value = _make_mock_trainer()
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import (
+            ExperimentsRunner, RunResult,
+        )
+        # Pre-write a complete state file
+        import dataclasses
+        completed = [
+            dataclasses.asdict(RunResult(
+                run_idx=i, seed=s, training_time_seconds=10.0,
+                train_metrics={}, val_metrics={"val/loss": 0.5},
+                test_metrics={}, output_dir=f"/tmp/run_{i:02d}_seed{s}",
+            ))
+            for i, s in enumerate([42, 101])
+        ]
+        state = {"all_seeds": [42, 101], "completed_runs": completed}
+        os.makedirs(self.tmp, exist_ok=True)
+        with open(os.path.join(self.tmp, "runner_state.json"), "w") as f:
+            json.dump(state, f)
+
+        cfg = self._make_cfg(seeds=[42, 101], resume=False)
+        ExperimentsRunner(cfg).run()
+
+        # resume=False → all runs re-executed
+        self.assertEqual(mock_train.call_count, 2)
+
+    @patch(_TRAIN_PATH)
+    def test_resume_uses_seeds_from_state_not_new_random(self, mock_train):
+        """When n_runs is used and we resume, seeds come from state file."""
+        mock_train.return_value = _make_mock_trainer()
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import (
+            ExperimentsRunner, RunResult,
+        )
+        import dataclasses
+        fixed_seeds = [111111, 222222]
+        completed = [
+            dataclasses.asdict(RunResult(
+                run_idx=0, seed=111111, training_time_seconds=5.0,
+                train_metrics={}, val_metrics={"val/loss": 0.3},
+                test_metrics={}, output_dir=f"/tmp/run_00_seed111111",
+            ))
+        ]
+        state = {"all_seeds": fixed_seeds, "completed_runs": completed}
+        os.makedirs(self.tmp, exist_ok=True)
+        with open(os.path.join(self.tmp, "runner_state.json"), "w") as f:
+            json.dump(state, f)
+
+        # Use n_runs (would generate new random seeds) but resume=True
+        cfg = self._make_cfg(n_runs=2, resume=True)
+        results = ExperimentsRunner(cfg).run()
+
+        # Only run 1 should execute; its seed must be the one from state
+        self.assertEqual(mock_train.call_count, 1)
+        self.assertEqual(results[1].seed, 222222)
+
+    @patch(_TRAIN_PATH)
+    def test_resume_no_state_file_starts_fresh(self, mock_train):
+        """resume=True with no state file on disk must not crash."""
+        mock_train.return_value = _make_mock_trainer()
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        cfg = self._make_cfg(seeds=[42, 101], resume=True)
+        results = ExperimentsRunner(cfg).run()
+        self.assertEqual(mock_train.call_count, 2)
+        self.assertEqual(len(results), 2)

--- a/tests/test_experiments_runner.py
+++ b/tests/test_experiments_runner.py
@@ -1,0 +1,393 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for ExperimentsRunner (TDD — written before implementation).
+
+Run with:
+    uv run pytest tests/test_experiments_runner.py -v --tb=short
+"""
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+import pytorch_lightning as pl
+from omegaconf import OmegaConf
+
+from tests.utils import BasicTestCase
+
+
+def _make_runner_cfg(
+    seeds=None,
+    n_runs=None,
+    output_base_dir=None,
+    save_summary=False,
+    summary_metrics=None,
+    extra=None,
+):
+    """Build a minimal DictConfig that ExperimentsRunner accepts."""
+    runner_block = {"output_base_dir": output_base_dir or "/tmp/test_runs"}
+    if seeds is not None:
+        runner_block["seeds"] = seeds
+    if n_runs is not None:
+        runner_block["n_runs"] = n_runs
+    runner_block["save_summary"] = save_summary
+    runner_block["summary_metrics"] = summary_metrics or ["val/loss"]
+    if extra:
+        runner_block.update(extra)
+
+    cfg = {
+        "mode": "run-experiments",
+        "experiments_runner": runner_block,
+        "seed": 0,
+        "hyperparameters": {"batch_size": 1, "epochs": 1, "max_lr": 0.1},
+        "pl_trainer": {
+            "max_epochs": 1,
+            "accelerator": "cpu",
+            "devices": 1,
+            "default_root_dir": "/old/path",
+        },
+    }
+    return OmegaConf.create(cfg)
+
+
+def _make_mock_trainer(metrics=None):
+    mock_trainer = MagicMock(spec=pl.Trainer)
+    mock_trainer.callback_metrics = metrics or {"val/loss": 0.5, "train/loss": 0.3}
+    return mock_trainer
+
+
+class TestExperimentsRunnerValidation(BasicTestCase):
+    """Config validation — no seeds and no n_runs must raise; conflicts must raise."""
+
+    def _import(self):
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import (
+            ExperimentsRunner,
+        )
+        return ExperimentsRunner
+
+    def test_raises_when_both_absent(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg()  # neither seeds nor n_runs
+        with self.assertRaises(ValueError):
+            ExperimentsRunner(cfg)
+
+    def test_raises_when_seeds_and_n_runs_conflict(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(seeds=[42, 101, 28], n_runs=1)
+        with self.assertRaises(ValueError):
+            ExperimentsRunner(cfg)
+
+    def test_valid_with_only_seeds(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(seeds=[42, 101])
+        runner = ExperimentsRunner(cfg)
+        self.assertIsNotNone(runner)
+
+    def test_valid_with_only_n_runs(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(n_runs=3)
+        runner = ExperimentsRunner(cfg)
+        self.assertIsNotNone(runner)
+
+    def test_valid_when_seeds_and_n_runs_consistent(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(seeds=[42, 101, 28], n_runs=3)
+        runner = ExperimentsRunner(cfg)
+        self.assertIsNotNone(runner)
+
+
+class TestResolveSeeds(BasicTestCase):
+    """_resolve_seeds() must return the right list of seeds."""
+
+    def _import(self):
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import (
+            ExperimentsRunner,
+        )
+        return ExperimentsRunner
+
+    def test_explicit_seeds_returned_as_is(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(seeds=[42, 101, 28])
+        seeds = ExperimentsRunner(cfg)._resolve_seeds()
+        self.assertEqual(seeds, [42, 101, 28])
+
+    def test_auto_seeds_have_correct_count(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(n_runs=5)
+        seeds = ExperimentsRunner(cfg)._resolve_seeds()
+        self.assertEqual(len(seeds), 5)
+
+    def test_auto_seeds_are_in_valid_range(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(n_runs=10)
+        seeds = ExperimentsRunner(cfg)._resolve_seeds()
+        self.assertTrue(all(0 <= s < 2**31 for s in seeds))
+
+    def test_auto_seeds_are_different_each_call(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(n_runs=4)
+        runner = ExperimentsRunner(cfg)
+        seeds1 = runner._resolve_seeds()
+        seeds2 = runner._resolve_seeds()
+        # Probability of collision: (2^31)^-4 ≈ 0
+        self.assertNotEqual(seeds1, seeds2)
+
+    def test_n_runs_derived_from_seeds_length(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(seeds=[1, 2, 3, 4])
+        runner = ExperimentsRunner(cfg)
+        self.assertEqual(runner._n_runs(), 4)
+
+
+class TestBuildRunCfg(BasicTestCase):
+    """_build_run_cfg() must return a clean config with correct seed and paths."""
+
+    def _import(self):
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import (
+            ExperimentsRunner,
+        )
+        return ExperimentsRunner
+
+    def test_seed_is_set_correctly(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(seeds=[42, 101])
+        run_cfg, _ = ExperimentsRunner(cfg)._build_run_cfg(0, 42)
+        self.assertEqual(run_cfg.seed, 42)
+
+    def test_experiments_runner_block_removed(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(seeds=[42])
+        run_cfg, _ = ExperimentsRunner(cfg)._build_run_cfg(0, 42)
+        self.assertNotIn("experiments_runner", run_cfg)
+
+    def test_mode_preserved(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(seeds=[42])
+        run_cfg, _ = ExperimentsRunner(cfg)._build_run_cfg(0, 42)
+        self.assertIn("mode", run_cfg)
+
+    def test_output_dir_ends_with_correct_run_folder(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(seeds=[42, 101], output_base_dir="/base/runs")
+        _, output_dir = ExperimentsRunner(cfg)._build_run_cfg(1, 101)
+        self.assertTrue(output_dir.endswith("run_01"))
+
+    def test_pl_trainer_default_root_dir_updated(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(seeds=[42], output_base_dir="/base/runs")
+        run_cfg, output_dir = ExperimentsRunner(cfg)._build_run_cfg(0, 42)
+        self.assertEqual(run_cfg.pl_trainer.default_root_dir, output_dir)
+
+    def test_run_idx_zero_padding(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(seeds=[42], output_base_dir="/base")
+        _, output_dir = ExperimentsRunner(cfg)._build_run_cfg(0, 42)
+        self.assertIn("run_00", output_dir)
+
+    def test_second_run_idx_formatted(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(seeds=[42, 99], output_base_dir="/base")
+        _, output_dir = ExperimentsRunner(cfg)._build_run_cfg(9, 99)
+        self.assertIn("run_09", output_dir)
+
+
+class TestCollectMetrics(BasicTestCase):
+    """_collect_metrics() must split trainer.callback_metrics by prefix."""
+
+    def _import(self):
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import (
+            ExperimentsRunner,
+        )
+        return ExperimentsRunner
+
+    def test_val_metrics_separated(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(seeds=[42])
+        runner = ExperimentsRunner(cfg)
+        trainer = _make_mock_trainer({"val/loss": 0.35, "train/loss": 0.2, "test/iou": 0.75})
+        _, val, _ = runner._collect_metrics(trainer)
+        self.assertIn("val/loss", val)
+        self.assertNotIn("train/loss", val)
+
+    def test_train_metrics_separated(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(seeds=[42])
+        runner = ExperimentsRunner(cfg)
+        trainer = _make_mock_trainer({"val/loss": 0.35, "train/loss": 0.2})
+        train, _, _ = runner._collect_metrics(trainer)
+        self.assertIn("train/loss", train)
+        self.assertNotIn("val/loss", train)
+
+    def test_test_metrics_separated(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(seeds=[42])
+        runner = ExperimentsRunner(cfg)
+        trainer = _make_mock_trainer({"test/iou": 0.75, "val/loss": 0.3})
+        _, _, test = runner._collect_metrics(trainer)
+        self.assertIn("test/iou", test)
+
+    def test_metric_values_are_float(self):
+        ExperimentsRunner = self._import()
+        cfg = _make_runner_cfg(seeds=[42])
+        runner = ExperimentsRunner(cfg)
+        import torch
+        trainer = _make_mock_trainer({"val/loss": torch.tensor(0.42)})
+        _, val, _ = runner._collect_metrics(trainer)
+        self.assertIsInstance(val["val/loss"], float)
+
+
+_TRAIN_PATH = (
+    "pytorch_segmentation_models_trainer"
+    ".tools.experiments_runner.experiments_runner.train"
+)
+
+
+class TestRunMethod(BasicTestCase):
+    """run() integration: correct number of calls, results, timing, CSV."""
+
+    def setUp(self):
+        super().setUp()
+        self.tmp = self.make_temp_dir()
+
+    def _make_cfg(self, seeds=None, n_runs=None, save_summary=False, metrics=None):
+        return _make_runner_cfg(
+            seeds=seeds,
+            n_runs=n_runs,
+            output_base_dir=self.tmp,
+            save_summary=save_summary,
+        )
+
+    @patch(_TRAIN_PATH)
+    def test_train_called_once_per_seed(self, mock_train):
+        mock_train.return_value = _make_mock_trainer()
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        runner = ExperimentsRunner(self._make_cfg(seeds=[42, 101, 28]))
+        runner.run()
+        self.assertEqual(mock_train.call_count, 3)
+
+    @patch(_TRAIN_PATH)
+    def test_returns_one_result_per_run(self, mock_train):
+        mock_train.return_value = _make_mock_trainer()
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        results = ExperimentsRunner(self._make_cfg(seeds=[42, 101])).run()
+        self.assertEqual(len(results), 2)
+
+    @patch(_TRAIN_PATH)
+    def test_result_seeds_match_config(self, mock_train):
+        mock_train.return_value = _make_mock_trainer()
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        results = ExperimentsRunner(self._make_cfg(seeds=[42, 101])).run()
+        self.assertEqual(results[0].seed, 42)
+        self.assertEqual(results[1].seed, 101)
+
+    @patch(_TRAIN_PATH)
+    def test_result_run_idx_sequential(self, mock_train):
+        mock_train.return_value = _make_mock_trainer()
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        results = ExperimentsRunner(self._make_cfg(seeds=[10, 20, 30])).run()
+        self.assertEqual([r.run_idx for r in results], [0, 1, 2])
+
+    @patch(_TRAIN_PATH)
+    def test_training_time_non_negative(self, mock_train):
+        mock_train.return_value = _make_mock_trainer()
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        results = ExperimentsRunner(self._make_cfg(seeds=[42])).run()
+        self.assertGreaterEqual(results[0].training_time_seconds, 0.0)
+
+    @patch(_TRAIN_PATH)
+    def test_val_metrics_in_result(self, mock_train):
+        mock_train.return_value = _make_mock_trainer({"val/loss": 0.35, "train/loss": 0.2})
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        results = ExperimentsRunner(self._make_cfg(seeds=[42])).run()
+        self.assertIn("val/loss", results[0].val_metrics)
+        self.assertAlmostEqual(results[0].val_metrics["val/loss"], 0.35, places=4)
+
+    @patch(_TRAIN_PATH)
+    def test_train_metrics_in_result(self, mock_train):
+        mock_train.return_value = _make_mock_trainer({"val/loss": 0.5, "train/loss": 0.2})
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        results = ExperimentsRunner(self._make_cfg(seeds=[42])).run()
+        self.assertIn("train/loss", results[0].train_metrics)
+
+    @patch(_TRAIN_PATH)
+    def test_test_metrics_in_result(self, mock_train):
+        mock_train.return_value = _make_mock_trainer({"test/iou": 0.75, "val/loss": 0.3})
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        results = ExperimentsRunner(self._make_cfg(seeds=[42])).run()
+        self.assertIn("test/iou", results[0].test_metrics)
+
+    @patch(_TRAIN_PATH)
+    def test_correct_seed_passed_to_each_run_cfg(self, mock_train):
+        mock_train.return_value = _make_mock_trainer()
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        ExperimentsRunner(self._make_cfg(seeds=[42, 101, 28])).run()
+        seeds_used = [c.args[0].seed for c in mock_train.call_args_list]
+        self.assertEqual(seeds_used, [42, 101, 28])
+
+    @patch(_TRAIN_PATH)
+    def test_experiments_runner_block_absent_in_train_call(self, mock_train):
+        mock_train.return_value = _make_mock_trainer()
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        ExperimentsRunner(self._make_cfg(seeds=[42])).run()
+        cfg_passed = mock_train.call_args.args[0]
+        self.assertNotIn("experiments_runner", cfg_passed)
+
+    @patch(_TRAIN_PATH)
+    def test_n_runs_auto_seeds(self, mock_train):
+        mock_train.return_value = _make_mock_trainer()
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        results = ExperimentsRunner(self._make_cfg(n_runs=3)).run()
+        self.assertEqual(len(results), 3)
+        self.assertEqual(mock_train.call_count, 3)
+
+    @patch(_TRAIN_PATH)
+    def test_summary_csv_created_when_enabled(self, mock_train):
+        mock_train.return_value = _make_mock_trainer({"val/loss": 0.5})
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        ExperimentsRunner(self._make_cfg(seeds=[42, 101], save_summary=True)).run()
+        self.assertTrue(os.path.exists(os.path.join(self.tmp, "summary.csv")))
+
+    @patch(_TRAIN_PATH)
+    def test_summary_csv_not_created_when_disabled(self, mock_train):
+        mock_train.return_value = _make_mock_trainer()
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        ExperimentsRunner(self._make_cfg(seeds=[42], save_summary=False)).run()
+        self.assertFalse(os.path.exists(os.path.join(self.tmp, "summary.csv")))
+
+    @patch(_TRAIN_PATH)
+    def test_summary_csv_has_mean_and_std_rows(self, mock_train):
+        mock_train.return_value = _make_mock_trainer({"val/loss": 0.5})
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        ExperimentsRunner(self._make_cfg(seeds=[42, 101], save_summary=True)).run()
+        with open(os.path.join(self.tmp, "summary.csv")) as f:
+            content = f.read()
+        self.assertIn("mean", content)
+        self.assertIn("std", content)
+
+    @patch(_TRAIN_PATH)
+    def test_summary_csv_has_duration_column(self, mock_train):
+        mock_train.return_value = _make_mock_trainer({"val/loss": 0.5})
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        ExperimentsRunner(self._make_cfg(seeds=[42, 101], save_summary=True)).run()
+        with open(os.path.join(self.tmp, "summary.csv")) as f:
+            header = f.readline()
+        self.assertIn("duration_s", header)
+
+    @patch(_TRAIN_PATH)
+    def test_result_output_dir_matches_run_folder(self, mock_train):
+        mock_train.return_value = _make_mock_trainer()
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        results = ExperimentsRunner(self._make_cfg(seeds=[42])).run()
+        self.assertIn("run_00", results[0].output_dir)
+
+    @patch(_TRAIN_PATH)
+    def test_single_run_std_row_is_zero(self, mock_train):
+        """With a single run, std must not raise and should be 0."""
+        mock_train.return_value = _make_mock_trainer({"val/loss": 0.5})
+        from pytorch_segmentation_models_trainer.tools.experiments_runner.experiments_runner import ExperimentsRunner
+        # Must not raise even with a single result
+        ExperimentsRunner(self._make_cfg(seeds=[42], save_summary=True)).run()
+        with open(os.path.join(self.tmp, "summary.csv")) as f:
+            content = f.read()
+        self.assertIn("std", content)

--- a/website/docs/user-guide/experiments_runner.md
+++ b/website/docs/user-guide/experiments_runner.md
@@ -56,8 +56,9 @@ pytorch-smt --config-path . --config-name my_experiment
 | `seeds` | `list[int]` | one of seeds/n_runs | — | Explicit seed list.  Determines the number of runs. |
 | `n_runs` | `int` | one of seeds/n_runs | — | Number of runs with auto-generated seeds.  Required when `seeds` is absent. |
 | `output_base_dir` | `str` | no | `outputs/experiments_runner` | Root directory for per-run outputs. |
-| `save_summary` | `bool` | no | `true` | Write `summary.csv` after all runs. |
+| `save_summary` | `bool` | no | `true` | Update `summary.csv` after every completed run. |
 | `summary_metrics` | `list[str]` | no | `[val/loss]` | Metric keys logged to the run summary table. |
+| `resume` | `bool` | no | `false` | Skip already-completed runs on restart using `runner_state.json`. |
 
 ### Seeds vs n\_runs
 
@@ -74,14 +75,17 @@ pytorch-smt --config-path . --config-name my_experiment
 
 ```
 outputs/my_study/
-├── run_00/          ← Lightning checkpoints & logs (seed 42)
-│   └── ...
-├── run_01/          ← Lightning checkpoints & logs (seed 101)
-│   └── ...
-├── run_02/          ← Lightning checkpoints & logs (seed 28)
-│   └── ...
-└── summary.csv
+├── run_00_seed42/        ← Lightning checkpoints & logs
+│   └── lightning_logs/
+├── run_01_seed101/
+│   └── lightning_logs/
+├── run_02_seed28/
+│   └── lightning_logs/
+├── runner_state.json     ← written after each run; drives resume
+└── summary.csv           ← updated after each run
 ```
+
+The seed is embedded in every directory name so you can identify an experiment directly from the filesystem without consulting `summary.csv`.
 
 ### summary.csv format
 
@@ -104,25 +108,45 @@ available metrics.
 ## Using random seeds
 
 When `seeds` is omitted and only `n_runs` is specified, the runner generates
-cryptographically random 31-bit seeds at runtime.  They are stored in
-`summary.csv` so you can reproduce any individual run later:
+cryptographically random 31-bit seeds at runtime.  They are saved in
+`runner_state.json` immediately so `resume: true` always uses the same seeds:
 
 ```yaml
 experiments_runner:
   n_runs: 5
   output_base_dir: outputs/random_study
   save_summary: true
+  resume: false
 ```
 
-To replay run 2 (seed from `summary.csv`, e.g. 1084739421):
+To replay an individual run, read its seed from the directory name
+(`run_02_seed1084739421/`) or from `summary.csv`:
 
 ```yaml
 mode: train
 seed: 1084739421
 pl_trainer:
-  default_root_dir: outputs/random_study/run_02_replay
+  default_root_dir: outputs/random_study/run_02_seed1084739421_replay
 # ... rest of config unchanged ...
 ```
+
+---
+
+## Resuming an interrupted run sequence
+
+If training is interrupted between runs, restart with `resume: true`:
+
+```yaml
+experiments_runner:
+  seeds: [42, 101, 28]
+  output_base_dir: outputs/my_study
+  resume: true           # reads runner_state.json, skips completed runs
+```
+
+The runner reads `runner_state.json`, identifies which runs already have
+results, and starts from the first pending run.  For within-run resumption
+(interrupted mid-epoch), configure PyTorch Lightning's `ModelCheckpoint`
+callback and set `resume_from_checkpoint` in `hyperparameters` as usual.
 
 ---
 

--- a/website/docs/user-guide/experiments_runner.md
+++ b/website/docs/user-guide/experiments_runner.md
@@ -1,0 +1,150 @@
+---
+sidebar_position: 13
+title: Experiments Runner
+---
+
+# Experiments Runner
+
+The Experiments Runner lets you repeat a training configuration multiple times
+with different random seeds — in series — and automatically aggregates the
+results into a single CSV file.  This is the recommended workflow for
+**reproducibility studies**, **variance estimation**, and **ablation
+comparisons**.
+
+---
+
+## Quick start
+
+```yaml
+# my_experiment.yaml
+mode: run-experiments
+
+experiments_runner:
+  seeds: [42, 101, 28]          # one run per seed
+  output_base_dir: outputs/my_study
+  save_summary: true
+  summary_metrics:
+    - val/loss
+    - val/F1Score
+
+# ... rest of the config is identical to a regular training config ...
+backbone:
+  name: resnet34
+  input_width: 256
+  input_height: 256
+
+hyperparameters:
+  model_name: unet_resnet34
+  backbone: resnet34
+  batch_size: 8
+  epochs: 50
+  max_lr: 1e-3
+  classes: 1
+# ...
+```
+
+```bash
+pytorch-smt --config-path . --config-name my_experiment
+```
+
+---
+
+## `experiments_runner` block reference
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `seeds` | `list[int]` | one of seeds/n_runs | — | Explicit seed list.  Determines the number of runs. |
+| `n_runs` | `int` | one of seeds/n_runs | — | Number of runs with auto-generated seeds.  Required when `seeds` is absent. |
+| `output_base_dir` | `str` | no | `outputs/experiments_runner` | Root directory for per-run outputs. |
+| `save_summary` | `bool` | no | `true` | Write `summary.csv` after all runs. |
+| `summary_metrics` | `list[str]` | no | `[val/loss]` | Metric keys logged to the run summary table. |
+
+### Seeds vs n\_runs
+
+| Configuration | Result |
+|---|---|
+| `seeds: [42, 101, 28]` | 3 runs with seeds 42, 101, 28 |
+| `n_runs: 5` | 5 runs with cryptographically random seeds |
+| `seeds: [42, 101, 28]`, `n_runs: 3` | 3 runs (consistent — accepted) |
+| `seeds: [42, 101, 28]`, `n_runs: 1` | **Validation error** (conflict) |
+
+---
+
+## Output layout
+
+```
+outputs/my_study/
+├── run_00/          ← Lightning checkpoints & logs (seed 42)
+│   └── ...
+├── run_01/          ← Lightning checkpoints & logs (seed 101)
+│   └── ...
+├── run_02/          ← Lightning checkpoints & logs (seed 28)
+│   └── ...
+└── summary.csv
+```
+
+### summary.csv format
+
+```
+run,seed,duration_s,train/loss,val/loss,val/F1Score
+0,42,142.30,0.210000,0.340000,0.820000
+1,101,139.80,0.190000,0.330000,0.825000
+2,28,141.10,0.200000,0.350000,0.818000
+mean,-,141.07,0.200000,0.340000,0.821000
+std,-,1.26,0.010000,0.010000,0.003606
+```
+
+Every metric logged by PyTorch Lightning (`train/*`, `val/*`, `test/*`) is
+included automatically.  The `summary_metrics` field only controls which
+metrics appear in the run-level log output — the CSV always contains all
+available metrics.
+
+---
+
+## Using random seeds
+
+When `seeds` is omitted and only `n_runs` is specified, the runner generates
+cryptographically random 31-bit seeds at runtime.  They are stored in
+`summary.csv` so you can reproduce any individual run later:
+
+```yaml
+experiments_runner:
+  n_runs: 5
+  output_base_dir: outputs/random_study
+  save_summary: true
+```
+
+To replay run 2 (seed from `summary.csv`, e.g. 1084739421):
+
+```yaml
+mode: train
+seed: 1084739421
+pl_trainer:
+  default_root_dir: outputs/random_study/run_02_replay
+# ... rest of config unchanged ...
+```
+
+---
+
+## Test dataset
+
+If your config contains a `test_dataset` block, PyTorch Lightning's
+`trainer.test()` is called at the end of each run and the `test/*` metrics are
+captured in `summary.csv` automatically — no extra configuration required.
+
+---
+
+## Relation to Reproducible Training
+
+The Experiments Runner builds on the [Reproducible Training](reproducibility.md)
+feature.  Each run receives its seed through the same `set_training_seed()`
+mechanism (seeding Python `random`, NumPy, PyTorch CPU/CUDA, and DataLoader
+workers).  You can also set `deterministic_cudnn: true` in the config for fully
+deterministic GPU ops at the cost of throughput.
+
+---
+
+## Full example config
+
+See [`conf/examples/experiments_runner.yaml`](https://github.com/dsgoficial/pytorch_segmentation_models_trainer/blob/main/pytorch_segmentation_models_trainer/conf/examples/experiments_runner.yaml)
+for a complete working example with a UNet / ResNet-34 backbone.


### PR DESCRIPTION
Introduces a new `run-experiments` mode that trains the same experiment
multiple times in series, each with an isolated seed and output directory,
and aggregates timing + metrics into a summary.csv.

Developed with TDD: 38 tests written before implementation, covering
validation, seed resolution, config mutation, metric collection, CSV
output, and the full run() integration with mocked trainer.

https://claude.ai/code/session_0127XwKyzzR1xYUVaW2pF5ri